### PR TITLE
Kill spawned process on websocket close.  Refactor to Endpoints.

### DIFF
--- a/endpoint.go
+++ b/endpoint.go
@@ -1,0 +1,13 @@
+// Copyright 2013 Joe Walnes and the websocketd team.
+// All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+type Endpoint interface {
+	Terminate()
+	Output() chan string
+	Send(msg string) bool
+}
+

--- a/launcher.go
+++ b/launcher.go
@@ -63,29 +63,36 @@ func parsePath(path string, config *Config) (*URLInfo, error) {
 	panic("parsePath")
 }
 
-func launchCmd(commandName string, commandArgs []string, env []string) (*exec.Cmd, io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {
+type LaunchedProcess struct {
+	cmd *exec.Cmd
+	stdin io.WriteCloser
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+}
+
+func launchCmd(commandName string, commandArgs []string, env []string) (*LaunchedProcess, error) {
 	cmd := exec.Command(commandName, commandArgs...)
 	cmd.Env = env
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return cmd, nil, nil, nil, err
+		return nil, err
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return cmd, nil, nil, nil, err
+		return nil, err
 	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return cmd, nil, nil, nil, err
+		return nil, err
 	}
 
 	err = cmd.Start()
 	if err != nil {
-		return cmd, nil, nil, nil, err
+		return nil, err
 	}
 
-	return cmd, stdin, stdout, stderr, err
+	return &LaunchedProcess{cmd, stdin, stdout, stderr}, err
 }

--- a/process_endpoint.go
+++ b/process_endpoint.go
@@ -1,0 +1,93 @@
+// Copyright 2013 Joe Walnes and the websocketd team.
+// All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"io"
+	"log"
+)
+
+type ProcessEndpoint struct {
+	process    *LaunchedProcess
+	bufferedIn *bufio.Writer
+	output     chan string
+}
+
+func NewProcessEndpoint(process *LaunchedProcess) *ProcessEndpoint {
+	return &ProcessEndpoint{
+		process:    process,
+		bufferedIn: bufio.NewWriter(process.stdin),
+		output:     make(chan string)}
+}
+
+func (pe *ProcessEndpoint) Terminate() {
+	pe.process.stdin.Close()
+
+	err := pe.process.cmd.Process.Kill()
+	if err != nil {
+		log.Printf("websocketd failed to kill process %v", pe.process.cmd.Process.Pid)
+	}
+
+	err = pe.process.cmd.Wait()
+	if err != nil {
+		log.Printf("websocketd couldn't reap process %v", pe.process.cmd.Process.Pid)
+	}
+}
+
+func (pe *ProcessEndpoint) Output() chan string {
+	return pe.output
+}
+
+func (pe *ProcessEndpoint) Send(msg string) bool {
+	pe.bufferedIn.WriteString(msg)
+	pe.bufferedIn.WriteString("\n")
+	pe.bufferedIn.Flush()
+	return true
+}
+
+func (pe *ProcessEndpoint) ReadOutput(input io.ReadCloser, config *Config) {
+	bufin := bufio.NewReader(input)
+	for {
+		str, err := bufin.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				log.Fatalf("Unexpected while reading process stdout: ", err)
+			} else {
+				if config.Verbose {
+					log.Printf("process stdout: CLOSED")
+				}
+			}
+			break
+		}
+		msg := str[0 : len(str)-1] // Trim new line
+		if config.Verbose {
+			log.Printf("process: OUT : <%s>", msg)
+		}
+		pe.output <- msg
+	}
+	close(pe.output)
+}
+
+
+func (pe *ProcessEndpoint) pipeStdErr(config *Config) {
+	bufstderr := bufio.NewReader(pe.process.stderr)
+	for {
+		str, err := bufstderr.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				log.Fatal("Unexpected read from process: ", err)
+			} else {
+				if config.Verbose {
+					log.Print("process stderr: CLOSED")
+				}
+			}
+			break
+		}
+		msg := str[0 : len(str)-1] // Trim new line
+		log.Print("process: STDERR : ", msg)
+	}
+}

--- a/websocket_endpoint.go
+++ b/websocket_endpoint.go
@@ -1,0 +1,57 @@
+// Copyright 2013 Joe Walnes and the websocketd team.
+// All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"log"
+	"code.google.com/p/go.net/websocket"
+)
+
+type WebsocketEndpoint struct {
+	ws     *websocket.Conn
+	output chan string
+}
+
+func NewWebsocketEndpoint(ws *websocket.Conn) *WebsocketEndpoint {
+	return &WebsocketEndpoint{
+		ws:      ws,
+		output:     make(chan string)}
+}
+
+func (we *WebsocketEndpoint) Terminate() {
+}
+
+func (we *WebsocketEndpoint) Output() chan string {
+	return we.output
+}
+
+func (we *WebsocketEndpoint) Send(msg string) bool {
+	err := websocket.Message.Send(we.ws, msg)
+	if err != nil {
+		log.Print("websocket: SENDERROR: ", err)
+		return false
+	}
+	return true
+}
+
+func (we *WebsocketEndpoint) ReadOutput(config *Config) {
+	for {
+		var msg string
+		err := websocket.Message.Receive(we.ws, &msg)
+		if err != nil {
+			if config.Verbose {
+				log.Print("websocket: RECVERROR: ", err)
+				break
+			}
+			break
+		}
+		if config.Verbose {
+			log.Print("websocket: IN : <", msg, ">")
+		}
+		we.output <- msg
+	}
+	close(we.output)
+}


### PR DESCRIPTION
Endpoint interface has process and websocket implementations.
goroutines are still started in main.go.  Extracted pipeEndpoints,
which, along with Endpoints, should make it easier to test.

I was full of shit about closing stdin being enough to kill the
process.  You have to kill it, then reap it.
