### PR TITLE
Add bash example: simple chat server

### DIFF
--- a/examples/bash/chat.sh
+++ b/examples/bash/chat.sh
@@ -6,6 +6,12 @@
 # license that can be found in the LICENSE file.
 
 # Run a simple chat server: websocketd --devconsole --port 8080 ./chat.sh
+#
+# Please note that this example requires GNU tail, which is not the default
+# tail on OS X. Even though this script properly escapes the variables,
+# please keep in mind that it is in general a bad idea to read
+# untrusted data into variables and pass this onto the command line.
+
 echo "Please enter your name:"; read USER
 echo "[$(date)] ${USER} joined the chat" >> chat.log
 echo "[$(date)] Welcome to the chat ${USER}!"


### PR DESCRIPTION
In just five lines of bash, this simple chat server demonstrates that `websocketd` can also work with scripts that are interactive and multi-user.
