### PR TITLE
Make count html example works on firefox

### DIFF
--- a/examples/html/count.html
+++ b/examples/html/count.html
@@ -24,7 +24,7 @@
         document.body.style.backgroundColor = null;
       };
       ws.onmessage = function(event) {
-        document.getElementById('count').innerText = event.data;
+        document.getElementById('count').textContent = event.data;
       };
     </script>
 


### PR DESCRIPTION
element.innerText not W3C compliant
http://stackoverflow.com/questions/1359469/innertext-works-in-ie-but-not-in-firefox
