### PR TITLE
Improve bash examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ __count.sh__:
 
 ```sh
 #!/bin/bash
-for COUNT in $(seq 1 10); do
+for ((COUNT = 1; COUNT <= 10; COUNT++)); do
   echo $COUNT
   sleep 1
 done

--- a/examples/bash/count.sh
+++ b/examples/bash/count.sh
@@ -6,7 +6,7 @@
 # license that can be found in the LICENSE file.
 
 # Simple example script that counts to 10 at ~2Hz, then stops.
-for COUNT in $(seq 1 10)
+for ((COUNT = 1; COUNT <= 10; COUNT++))
 do
   echo $COUNT
   sleep 0.5

--- a/examples/bash/dump-env.sh
+++ b/examples/bash/dump-env.sh
@@ -33,7 +33,7 @@ NAMES="""
 
 for NAME in ${NAMES}
 do
-	echo ${NAME}=${!NAME:-<unset>}
+	echo "${NAME}=${!NAME:-<unset>}"
 done
 
 # Additional HTTP headers

--- a/examples/bash/send-receive.sh
+++ b/examples/bash/send-receive.sh
@@ -3,10 +3,10 @@
 
 while true; do
 	cnt=0
-	while read -t 0.01 line; do
-		cnt=$(($cnt + 1))
+	while read -t 0.01 _; do
+		((cnt++))
 	done
 
-	echo `date` "($cnt line(s) received)"
+	echo "$(date)" "($cnt line(s) received)"
 	sleep $((RANDOM % 10 + 1)) & wait
 done


### PR DESCRIPTION
See also http://www.shellcheck.net/

* examples/bash/count.sh,README.md: `seq` is nonstandard, inefficient.
  Use shell built-in loop feature instead.
* examples/bash/dump-env.sh: Double quote to prevent globbing (SC2086)
* examples/bash/send-receive.sh: Use _ for unused variable; Improved use
  of shell arithmetic ((cnt++)); Use $().