### PR TITLE
Python fixes

### DIFF
--- a/examples/python/count.py
+++ b/examples/python/count.py
@@ -10,6 +10,6 @@ from time import sleep
 
 # Simple example script that counts to 10 at ~2Hz, then stops.
 for count in range(0, 10):
-  print count + 1
+  print(count + 1)
   stdout.flush() # Remember to flush
   sleep(0.5)

--- a/examples/python/count.py
+++ b/examples/python/count.py
@@ -11,5 +11,5 @@ from time import sleep
 # Simple example script that counts to 10 at ~2Hz, then stops.
 for count in range(0, 10):
   print count + 1
-  sleep(0.5)
   stdout.flush() # Remember to flush
+  sleep(0.5)


### PR DESCRIPTION
Support python3 with count.py example and align stdout flushing in count.py with the behaviour of the count.sh.

Additionally, the Python example on the frontpage of http://websocketd.com/ needs an update. Since there is no flushing of stdout, the example only outputs at the end when the script finishes. Doesn't seem to be a github page, so no patch.