### PR TITLE
Flush output

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@ for count in range(0, 10):
 <pre class="code content-ruby"><code class="language-ruby">#!/usr/bin/ruby
 
 # Count from 1 to 10 with a sleep
+STDOUT.sync = true
 (1..10).each do |count|
 	puts count
 	sleep(0.5)
@@ -192,6 +193,7 @@ import AppKit
 
 for index in 1...10 {
   println(index)
+  fflush(__stdoutp)
   NSThread.sleepForTimeInterval(0.5)
 }</code></pre>
 


### PR DESCRIPTION
Without flushing the buffer, people won't see the counting step by step — instead they'll get everything at once, after the counting completed.