### PR TITLE
fixed for IE11 

### DIFF
--- a/libwebsocketd/console.go
+++ b/libwebsocketd/console.go
@@ -25,6 +25,7 @@ Full documentation at http://websocketd.com/
 
 <!DOCTYPE html>
 <meta charset="utf8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <title>websocketd console</title>
 
 <style>


### PR DESCRIPTION
if used inside a corporate where IE11 is set to be document mode compatible with an earlier version, say, 5, the  devconsole page fails to render because websocket is not support. I fixed it by forcing  *X-UA-Compatible* HTTP header value to be *"Edge"* inside the document.  Please accept it if you find it useful.