### PR TITLE
Fix display of tab characters in dev console

### DIFF
--- a/libwebsocketd/console.go
+++ b/libwebsocketd/console.go
@@ -93,6 +93,7 @@ Full documentation at http://websocketd.com/
 		margin-left: 90px;
 		display: block;
 		word-wrap: break-word;
+		white-space: pre;
 	}
 	.type-input,
 	.type-send {


### PR DESCRIPTION
If your program outputs multiple spaces or tab characters correctly display them in the dev console