### PR TITLE
examples/cgi-bin/dump-env.sh: drop bash dependency

### DIFF
--- a/examples/cgi-bin/dump-env.sh
+++ b/examples/cgi-bin/dump-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2013 Joe Walnes and the websocketd team.
 # All rights reserved.
@@ -36,7 +36,8 @@ echo
 
 for NAME in ${NAMES}
 do
-	echo ${NAME}=${!NAME:-<unset>}
+	eval "value=\${${NAME}}"
+	env -i "${NAME}=${value:-<unset>}"
 done
 
 # Additional HTTP headers


### PR DESCRIPTION
Replace bashisms with more portable sh idioms.  This should both work out
of the box on more systems, and also fixes the example on systems like
OpenBSD where the official system bash package installs the executable
in a location other than /bin.

Original patch from Dmitrij D. Czarkoff <czarkoff@openbsd.org> with
tweaks from me.

Signed-off-by: Kent R. Spillner <kspillner@acm.org>