### PR TITLE
Fix swift examples not compiling with latest Swift release

### DIFF
--- a/examples/swift/count.swift
+++ b/examples/swift/count.swift
@@ -3,7 +3,7 @@
 import AppKit
 
 for index in 1...10 {
-  println(index)
+  print(index)
   
   // Flush output
   fflush(__stdoutp)

--- a/examples/swift/greeter.swift
+++ b/examples/swift/greeter.swift
@@ -6,6 +6,6 @@ while(true){
   var stdin = NSFileHandle.fileHandleWithStandardInput().availableData
   var line  = NSString(data: stdin, encoding: NSUTF8StringEncoding)!
   var name  = line.stringByTrimmingCharactersInSet(NSCharacterSet.newlineCharacterSet())
-  println("Hello \(name)!")
+  print("Hello \(name)!")
   fflush(__stdoutp)
 }


### PR DESCRIPTION
`println` must be replaced with `print` in order to compile with latest Swift release (2.1.1)