### PR TITLE
Fixed doubling binary frames in size

### DIFF
--- a/libwebsocketd/process_endpoint.go
+++ b/libwebsocketd/process_endpoint.go
@@ -132,7 +132,7 @@ func (pe *ProcessEndpoint) process_binout() {
 			}
 			break
 		}
-		pe.output <- append(make([]byte, n), buf[:n]...) // cloned buffer
+		pe.output <- append(make([]byte, 0, n), buf[:n]...) // cloned buffer
 	}
 	close(pe.output)
 }


### PR DESCRIPTION
Caused by the fact that a slice was allocated for the read data of size `n`,and then the data was appended. However, `append(...)` does not overwrite the contents of the slice, it makes it grow larger. Thus, the resulting slice is `n * 2`.