### PR TITLE
Changed default for reverselookup option to false

### DIFF
--- a/config.go
+++ b/config.go
@@ -77,7 +77,7 @@ func parseCommandLine() *Config {
 
 	// lib config options
 	binaryFlag := flag.Bool("binary", false, "Set websocketd to experimental binary mode (default is line by line)")
-	reverseLookupFlag := flag.Bool("reverselookup", true, "Perform reverse DNS lookups on remote clients")
+	reverseLookupFlag := flag.Bool("reverselookup", false, "Perform reverse DNS lookups on remote clients")
 	scriptDirFlag := flag.String("dir", "", "Base directory for WebSocket scripts")
 	staticDirFlag := flag.String("staticdir", "", "Serve static content from this directory over HTTP")
 	cgiDirFlag := flag.String("cgidir", "", "Serve CGI scripts from this directory over HTTP")

--- a/help.go
+++ b/help.go
@@ -65,7 +65,7 @@ Options:
                                  Default: false
 
   --reverselookup={true,false}   Perform DNS reverse lookups on remote clients.
-                                 Default: true
+                                 Default: false
 
   --dir=DIR                      Allow all scripts in the local directory
                                  to be accessed as WebSockets. If using this,


### PR DESCRIPTION
See #230 for details, there is additional overhead and minor security risk associated with checking reverse DNS name for each request. Best practices currently recommend against it.