### PR TITLE
Add example project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Example Projects
 
 *   [Plot real time Linux CPU/IO/Mem stats to a HTML5 dashboard using websocketd and vmstat](https://github.com/joewalnes/web-vmstats) _(for Linux)_
 *   [Remote JScript & VBScript code execution tool based on websocketd](https://github.com/dab00/ws-console) _(for Windows)_
+*   [Arbitrary REPL in the browser using websocketd](https://github.com/rowanthorpe/ws-repl)
 
 Got more examples? Open a pull request.
 


### PR DESCRIPTION
As suggested in your README, this adds a link to my project 'ws-repl' which is a simple wrapper I wrote to use websocketd as a backend to provide arbitrary STDIN/STDOUT-based REPLs in the browser.