### PR TITLE
Add support for building snaps

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: websocketd
+version: '1.0'
+summary: Turn any program that uses STDIN/STDOUT into a WebSocket server 
+description: |
+  Turn any program that uses STDIN/STDOUT into a WebSocket server. Like inetd, but for WebSockets. 
+grade: stable
+confinement: strict
+base: core18
+parts:
+  websocketd:
+    plugin: go
+    source: https://github.com/joewalnes/websocketd.git
+    go-importpath: github.com/joewalnes/websocketd
+    build-packages:
+      - build-essential
+apps:
+  websocketd:
+    command: bin/websocketd
+    daemon: simple
+    restart-condition: on-abnormal
+    plugs:
+      - home
+      - network
+      - network-bind


### PR DESCRIPTION
Hey Joe,

Where are you going with that app in your hand?

That was supposed to be a funny line, now the serious part. I came across your project on GH and created a snap of it. The same way websocket wraps CLI programs, snap wrap programs into standalone applications. So we have a bit of inception here (another joke) :)

Anyway, snaps are cross-distro Linux software packages, and can be installed on a wide range of Linux distros. They are automatically updated, and they are featured in the Snap Store (https://snapcraft.io/store), which is accessible to millions of Linux folks. I thought you might be interested in adding your own software here.

This PR is about adding snap support - it contains a snapcraft.yaml file, which is "recipe" for building snaps.

If you use this YAML, you can package websocketd as a snap, and then upload it to the store.

The actual steps are as follows:

- Install snapcraft (command line for building snaps - and later publishing them).
- Clone and checkout the add-snapcraft branch of your project
- Run snapcraft to build the snap
- Install snap locally to test functionality
- Register a dev account in the Snap Store
- Login and upload the websocketd snap

If you are not familiar with snapcraft, I can help you with the syntax.

We'd be happy to feature your app in our store.

Take care.
