### PR TITLE
Fix long line breaking in help output

### DIFF
--- a/help.go
+++ b/help.go
@@ -58,7 +58,7 @@ Options:
 
   --passenv VAR[,VAR...]         Lists environment variables allowed to be
                                  passed to executed scripts. Does not work for
-																 Windows since all the variables are kept there.
+                                 Windows since all the variables are kept there.
 
   --binary={true,false}          Switches communication to binary, process reads
                                  send to browser as blobs and all reads from the


### PR DESCRIPTION

<img width="972" alt="屏幕快照 2019-09-17 上午11 41 06" src="https://user-images.githubusercontent.com/261698/65009748-6492fe00-d940-11e9-9c5b-58a83b79eadf.png">


Change many horizontal tabs to spaces to fix this.

