### PR TITLE
Add Controlloid example project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Example Projects
 *   [Arbitrary REPL in the browser using websocketd](https://github.com/rowanthorpe/ws-repl)
 *   [Retrieve SQL data from server with LiveCode and webSocketd](https://github.com/samansjukur/wslc)
 *   [List files from a configured folder](https://github.com/dbalakirev/directator) _(for Linux)_
+*   [Listen for gamepad events and report them to the system](https://github.com/experiment322/controlloid-server) _(this + android = gamepad emulator)_
 
 Got more examples? Open a pull request.
 


### PR DESCRIPTION
This project uses websockets (through websocketd) to transmit live gamepad events from a device (android-only client for the time being) to a Linux/Windows machine which then will report them to the system using the appropriate driver (with the help of a C program fed by websocketd).

The result of this is a nice gamepad emulation which seems to perform pretty well through websockets (even with the analog controls) and easily supports multiple simultaneous clients thanks to websocketd's architecture.

Note: The emulation should be done only on local area networks to achieve good emulation results.