### PR TITLE
Add mobile-friendly viewport to developer console

### DIFF
--- a/libwebsocketd/console.go
+++ b/libwebsocketd/console.go
@@ -25,6 +25,7 @@ Full documentation at http://websocketd.com/
 
 <!DOCTYPE html>
 <meta charset="utf8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>websocketd console</title>
 
 <style>


### PR DESCRIPTION
Adds [viewport meta tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag) to make the developer console more usable on mobile.