### PR TITLE
add PowerShell examples

### DIFF
--- a/examples/powershell/README.txt
+++ b/examples/powershell/README.txt
@@ -1,0 +1,7 @@
+This examples directory shows some examples written in PowerShell.
+
+On Windows, note that each .ps1 file also requires a .cmd file to launch it.
+The WebSocket should connect to ws://..../[example].cmd.
+On Linux this is not required due to the shebang (#!/usr/bin/env pwsh).
+
+You can also test the command files by running from the command line.

--- a/examples/powershell/count.cmd
+++ b/examples/powershell/count.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass %0\..\count.ps1

--- a/examples/powershell/count.ps1
+++ b/examples/powershell/count.ps1
@@ -1,0 +1,6 @@
+#!/usr/bin/env pwsh
+
+for ($i = 1 ; $i -le 10; $i++) {
+    Write-Host $i
+    Start-Sleep -Milliseconds 500
+}

--- a/examples/powershell/dump-env.cmd
+++ b/examples/powershell/dump-env.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass %0\..\dump-env.ps1

--- a/examples/powershell/dump-env.ps1
+++ b/examples/powershell/dump-env.ps1
@@ -1,0 +1,45 @@
+#!/usr/bin/env pwsh
+
+# Standard CGI(ish) environment variables, as defined in
+# http://tools.ietf.org/html/rfc3875
+$varNames = @(
+    "AUTH_TYPE",
+    "CONTENT_LENGTH",
+    "CONTENT_TYPE",
+    "GATEWAY_INTERFACE",
+    "PATH_INFO",
+    "PATH_TRANSLATED",
+    "QUERY_STRING",
+    "REMOTE_ADDR",
+    "REMOTE_HOST",
+    "REMOTE_IDENT",
+    "REMOTE_PORT",
+    "REMOTE_USER",
+    "REQUEST_METHOD",
+    "REQUEST_URI",
+    "SCRIPT_NAME",
+    "SERVER_NAME",
+    "SERVER_PORT",
+    "SERVER_PROTOCOL",
+    "SERVER_SOFTWARE",
+    "UNIQUE_ID",
+    "HTTPS"
+)
+
+$environmentVariables = [Environment]::GetEnvironmentVariables()
+
+foreach ($key in $varNames) {
+    $value = $environmentVariables.Item($key)
+    if ([string]::IsNullOrEmpty($value)) {
+        $value = "<unset>"
+    }
+    Write-Host "$key=$value"
+}
+
+# Additional HTTP headers
+foreach ($item in $environmentVariables.GetEnumerator()) {
+    $key, $value = $item.Key, $item.Value
+    if ($key.StartsWith("HTTP_")) {
+        Write-Host "$key=$value"
+    }
+}

--- a/examples/powershell/greeter.cmd
+++ b/examples/powershell/greeter.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass %0\..\greeter.ps1

--- a/examples/powershell/greeter.ps1
+++ b/examples/powershell/greeter.ps1
@@ -1,0 +1,7 @@
+#!/usr/bin/env pwsh
+
+# For each line FOO received on STDIN, respond with "Hello FOO!".
+while ($true) {
+    $line = Read-Host
+    Write-Host "Hello $line!"
+}


### PR DESCRIPTION
I was looking for an example of how to use websocketd with PowerShell on Windows. The provided .cmd files should be a good starting point. Tested on Windows 10 (PowerShell 5.1) and Ubuntu 18.04 (PowerShell 7.2).

Note: `dump-env.ps1` uses `GetEnvironmentVariables()` from .NET instead of the built-in `$Env:` drive to potentially support different scopes (process / user / machine) if needed.