### PR TITLE
fix(sec): upgrade github.com/gorilla/websocket to 1.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/joewalnes/websocketd
 
 go 1.15
 
-require github.com/gorilla/websocket v1.4.0
+require github.com/gorilla/websocket v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/gorilla/websocket v1.4.0
- [CVE-2020-27813](https://www.oscs1024.com/hd/CVE-2020-27813)


### What did I do？
Upgrade github.com/gorilla/websocket from v1.4.0 to 1.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS