### PR TITLE
Allow listening on a Unix Domain Socket

### DIFF
--- a/help.go
+++ b/help.go
@@ -36,6 +36,11 @@ Options:
                                  Use square brackets to specify IPv6 address.
                                  Default: "" (all)
 
+  --uds=PATH                     Path to create a Unix Domain Socket to listen
+                                 on. If this is specified and no IP-specific
+                                 flags are specified, do not listen on IP.
+                                 Default: "" (do not serve on UDS)
+
   --sameorigin={true,false}      Restrict (HTTP 403) protocol upgrades if the
                                  Origin header does not match to requested HTTP
                                  Host. Default: false.

--- a/libwebsocketd/handler.go
+++ b/libwebsocketd/handler.go
@@ -35,8 +35,9 @@ func NewWebsocketdHandler(s *WebsocketdServer, req *http.Request, log *LogScope)
 
 	wsh.RemoteInfo, err = GetRemoteInfo(req.RemoteAddr, s.Config.ReverseLookup)
 	if err != nil {
+		// This occurs when serving over Unix Domain Sockets.
 		log.Error("session", "Could not understand remote address '%s': %s", req.RemoteAddr, err)
-		return nil, err
+		wsh.RemoteInfo = &RemoteInfo{Addr: "unknown_host", Host: "unknown_host", Port: ""}
 	}
 	log.Associate("remote", wsh.RemoteInfo.Host)
 


### PR DESCRIPTION
I use this in conjunction with local SSH port forwarding. The benefit is that I can run a server on a remote machine without allowing other users with login access to reach it. The service becomes available on the SSH client on an IP port but on the SSH server only via a private socket.