### PR TITLE
fix show help message

### DIFF
--- a/config.go
+++ b/config.go
@@ -54,8 +54,8 @@ func parseCommandLine() *Config {
 	var mainConfig Config
 	var config libwebsocketd.Config
 
-	flag.Usage = func() {}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flag.CommandLine.Usage = func() {}
 
 	// If adding new command line options, also update the help text in help.go.
 	// The flag library's auto-generate help message isn't pretty enough.


### PR DESCRIPTION
When run `websocketd -h or -help or --help or --h` , The help message is executed twice, once show default `flag.Usage` help message and once `PrintHelp()` ,,

```
#./websocketd -h 
#./websocketd -help
#./websocketd --help
./websocketd --h

Usage of ./websocketd:
  -address value
      Interfaces to bind to (e.g. 127.0.0.1 or [::1]).

[...SNIP...]

  -version
      Print version and exit
websocketd (DEVBUILD (go1.18.3 linux-amd64) --)

websocketd is a command line tool that will allow any executable program

[...SNIP...]

Full documentation at http://websocketd.com/

Copyright 2013 Joe Walnes and the websocketd team. All rights reserved.
BSD license: Run 'websocketd --license' for details.

```
in this line
https://github.com/joewalnes/websocketd/blob/334a9ecc36f74a622f2a1899e4d9291a379e574f/config.go#L57
show default `flag.Usage` message disabled, but in next line 
https://github.com/joewalnes/websocketd/blob/334a9ecc36f74a622f2a1899e4d9291a379e574f/config.go#L58
created new instance of flag with `NewFlagSet` 

> NewFlagSet returns a new, empty flag set with the specified name and error handling property. If the name is not empty, it will be printed in the default usage message and in error messages. 

and we must set `flag.CommandLine.Usage` for stop printing default message