### PR TITLE
Update gorilla to 1.5.2, update go to 1.22.3, and add github action to build and test on each PR

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,4 +1,4 @@
-name: Makefile CI
+name: build and test
 
 on:
   push:
@@ -14,5 +14,42 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: make binary
-      run: make websocketd
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    # - name: build using makefile
+    #   run: make websocketd
+
+    - name: build websocketd
+      run: go build
+
+    - name: Archive build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: websocketd
+        path: |
+          websocketd
+          ./examples/bash/dump-env.sh
+
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download built websocketd
+      uses: actions/download-artifact@v4
+      with:
+        name: websocketd
+
+    - name: fix permissions
+      run: chmod +x ./websocketd && chmod +x ./examples/bash/dump-env.sh
+
+    - name: setup client
+      run: wget https://github.com/vi/websocat/releases/latest/download/websocat.x86_64-unknown-linux-musl && chmod +x websocat.x86_64-unknown-linux-musl 
+
+    - name: test
+      run: |
+        ./websocketd --port=8080 ./examples/bash/dump-env.sh &
+        ./websocat.x86_64-unknown-linux-musl -E ws://$(hostname):8080

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,18 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: make binary
+      run: make websocketd

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # To manually invoke the locally installed Go, use ./go
 
 # Go installation config.
-GO_VER=1.11.5
+GO_VER=1.22.3
 SYSTEM_NAME:=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 SYSTEM_ARCH:=$(shell uname -m)
 GO_ARCH:=$(if $(filter x86_64, $(SYSTEM_ARCH)),amd64,386)

--- a/config.go
+++ b/config.go
@@ -54,8 +54,8 @@ func parseCommandLine() *Config {
 	var mainConfig Config
 	var config libwebsocketd.Config
 
-	flag.Usage = func() {}
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flag.CommandLine.Usage = func() {}
 
 	// If adding new command line options, also update the help text in help.go.
 	// The flag library's auto-generate help message isn't pretty enough.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/joewalnes/websocketd
 
 go 1.15
 
-require github.com/gorilla/websocket v1.4.0
+require github.com/gorilla/websocket v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/joewalnes/websocketd
 
-go 1.15
+go 1.22.3
 
-require github.com/gorilla/websocket v1.4.1
+require github.com/gorilla/websocket v1.5.2
+
+require golang.org/x/net v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,7 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.2 h1:qoW6V1GT3aZxybsbC6oLnailWnB+qTMVwMreOso9XUw=
+github.com/gorilla/websocket v1.5.2/go.mod h1:0n9H61RBAcf5/38py2MCYbxzPIY9rOkpvvMT24Rqs30=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=

--- a/main.go
+++ b/main.go
@@ -94,13 +94,16 @@ func main() {
 				pos := strings.IndexByte(addr, ':')
 				rediraddr := addr[:pos] + ":" + strconv.Itoa(config.RedirPort) // it would be silly to optimize this one
 				redir := &http.Server{Addr: rediraddr, Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 					// redirect to same hostname as in request but different port and probably schema
 					uri := "https://"
 					if !config.Ssl {
 						uri = "http://"
 					}
-					uri += r.Host[:strings.IndexByte(r.Host, ':')] + addr[pos:] + "/"
+					if cpos := strings.IndexByte(r.Host, ':'); cpos > 0 {
+						uri += r.Host[:strings.IndexByte(r.Host, ':')] + addr[pos:] + "/"
+					} else {
+						uri += r.Host + addr[pos:] + "/"
+					}
 
 					http.Redirect(w, r, uri, http.StatusMovedPermanently)
 				})}

--- a/release/Makefile
+++ b/release/Makefile
@@ -21,7 +21,7 @@ LAST_PATCH_VERSION:=$(shell git ls-remote git@github.com:joewalnes/websocketd.gi
 VERSION_PATCH:=$(or $(LAST_PATCH_VERSION),0)
 RELEASE_VERSION=$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
 
-GO_VERSION=1.15.7
+GO_VERSION=1.22.3
 PLATFORMS=linux_amd64 linux_386 linux_arm linux_arm64 darwin_amd64 freebsd_amd64 freebsd_386 windows_386 windows_amd64 openbsd_386 openbsd_amd64 solaris_amd64
 
 


### PR DESCRIPTION
building off of https://github.com/joewalnes/websocketd/pull/430

also adds a github action to make sure the makefile builds binaries successfully before allowing a PR to be merged. also tests the binaries by connecting to the example bash script for dump env and making sure it sends an eof at the end
added an example in https://github.com/barakplasma/websocketd/actions/runs/9455903924

easier than using the makefile is to use go-releaser like I'm doing in my fork (generated by the github action workflow  at https://github.com/barakplasma/websocketd/blob/master/.github/workflows/release.yml )
I built binaries for all platforms on the latest golang in 
https://github.com/barakplasma/websocketd/releases/tag/0.4.2