### PR TITLE
Add PowerShell examples (count, greeter, dump-env)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Version 0.5.0 (Apr 26, 2026)
 
+* Added PowerShell examples (count, greeter, dump-env) alongside the existing
+  VBScript/JScript ones — cross-platform via PowerShell Core (#423, thanks
+  @kshahar)
 * Release version derivation uses HTTPS instead of SSH for git ls-remote
   (no SSH setup needed for a public repo)
 * Repaired release tooling: release/Makefile now builds 0.5.x (was stuck on

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ websocketd
 
 `websocketd` is a small command-line tool that will wrap an existing command-line interface program, and allow it to be accessed via a WebSocket.
 
-WebSocket-capable applications can now be built very easily. As long as you can write an executable program that reads `STDIN` and writes to `STDOUT`, you can build a WebSocket server. Do it in Python, Ruby, Perl, Bash, .NET, C, Go, PHP, Java, Clojure, Scala, Groovy, Expect, Awk, VBScript, Haskell, Lua, R, whatever! No networking libraries necessary.
+WebSocket-capable applications can now be built very easily. As long as you can write an executable program that reads `STDIN` and writes to `STDOUT`, you can build a WebSocket server. Do it in Python, Ruby, Perl, Bash, .NET, C, Go, PHP, Java, Clojure, Scala, Groovy, Expect, Awk, VBScript, PowerShell, Haskell, Lua, R, whatever! No networking libraries necessary.
 
 -[@joewalnes](https://twitter.com/joewalnes)
 

--- a/examples/powershell/README.txt
+++ b/examples/powershell/README.txt
@@ -1,0 +1,7 @@
+This examples directory shows some examples written in PowerShell.
+
+On Windows, note that each .ps1 file also requires a .cmd file to launch it.
+The WebSocket should connect to ws://..../[example].cmd.
+On Linux this is not required due to the shebang (#!/usr/bin/env pwsh).
+
+You can also test the command files by running from the command line.

--- a/examples/powershell/count.cmd
+++ b/examples/powershell/count.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass %0\..\count.ps1

--- a/examples/powershell/count.ps1
+++ b/examples/powershell/count.ps1
@@ -1,0 +1,6 @@
+#!/usr/bin/env pwsh
+
+for ($i = 1 ; $i -le 10; $i++) {
+    Write-Host $i
+    Start-Sleep -Milliseconds 500
+}

--- a/examples/powershell/dump-env.cmd
+++ b/examples/powershell/dump-env.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass %0\..\dump-env.ps1

--- a/examples/powershell/dump-env.ps1
+++ b/examples/powershell/dump-env.ps1
@@ -1,0 +1,45 @@
+#!/usr/bin/env pwsh
+
+# Standard CGI(ish) environment variables, as defined in
+# http://tools.ietf.org/html/rfc3875
+$varNames = @(
+    "AUTH_TYPE",
+    "CONTENT_LENGTH",
+    "CONTENT_TYPE",
+    "GATEWAY_INTERFACE",
+    "PATH_INFO",
+    "PATH_TRANSLATED",
+    "QUERY_STRING",
+    "REMOTE_ADDR",
+    "REMOTE_HOST",
+    "REMOTE_IDENT",
+    "REMOTE_PORT",
+    "REMOTE_USER",
+    "REQUEST_METHOD",
+    "REQUEST_URI",
+    "SCRIPT_NAME",
+    "SERVER_NAME",
+    "SERVER_PORT",
+    "SERVER_PROTOCOL",
+    "SERVER_SOFTWARE",
+    "UNIQUE_ID",
+    "HTTPS"
+)
+
+$environmentVariables = [Environment]::GetEnvironmentVariables()
+
+foreach ($key in $varNames) {
+    $value = $environmentVariables.Item($key)
+    if ([string]::IsNullOrEmpty($value)) {
+        $value = "<unset>"
+    }
+    Write-Host "$key=$value"
+}
+
+# Additional HTTP headers
+foreach ($item in $environmentVariables.GetEnumerator()) {
+    $key, $value = $item.Key, $item.Value
+    if ($key.StartsWith("HTTP_")) {
+        Write-Host "$key=$value"
+    }
+}

--- a/examples/powershell/greeter.cmd
+++ b/examples/powershell/greeter.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell -NoProfile -ExecutionPolicy Bypass %0\..\greeter.ps1

--- a/examples/powershell/greeter.ps1
+++ b/examples/powershell/greeter.ps1
@@ -1,0 +1,7 @@
+#!/usr/bin/env pwsh
+
+# For each line FOO received on STDIN, respond with "Hello FOO!".
+while ($true) {
+    $line = Read-Host
+    Write-Host "Hello $line!"
+}

--- a/qa/plans/07-platform-windows.md
+++ b/qa/plans/07-platform-windows.md
@@ -94,6 +94,21 @@ All tests in this file should be run on Windows 10 and Windows 11.
 
 ---
 
+## WIN-007: PowerShell Examples
+
+**Priority**: P2
+
+**Steps**:
+1. Run the provided PowerShell examples from `examples/powershell/` via
+   their `.cmd` wrappers on Windows (or directly via the `pwsh` shebang
+   on Linux/macOS)
+2. Connect and verify functionality
+
+**Expected Result**: PowerShell examples work correctly on Windows and,
+via PowerShell Core, on Linux/macOS.
+
+---
+
 ## WIN-007: Process Termination on Windows
 
 **Priority**: P0


### PR DESCRIPTION
## Summary

Rebase of #423 (by @kshahar) onto current master, with a few small additions.

- `examples/powershell/` — count, greeter, dump-env, mirroring the existing `windows-vbscript`/`windows-jscript` directories. Unlike those, PowerShell Core also runs on Linux/macOS via the `#!/usr/bin/env pwsh` shebang, so this isn't Windows-only.
- Mentioned PowerShell in the README language list
- Added QA plan entry WIN-007 alongside the existing VBScript/JScript ones
- Added a CHANGES entry crediting the original PR

## Safety review

Read every file — no eval of untrusted input anywhere:
- `count.ps1`: fixed 10-iteration loop, 500ms sleep (matches `bash/count.sh` timing exactly)
- `dump-env.ps1`: reads a fixed list of CGI env vars via `[Environment]::GetEnvironmentVariables()`, no injection surface
- `greeter.ps1`: `Read-Host` input is only interpolated into a `Write-Host` format string, never executed
- `.cmd` wrappers use `-ExecutionPolicy Bypass -NoProfile`, scoped to that one process invocation, matching the standard idiom for running unsigned scripts non-interactively (same pattern any CI system uses)

## Testing

- `go build`/`go test ./...` pass (these are example scripts, not covered by Go tests)
- `pwsh` isn't available in my environment to execute them directly, but the syntax is standard, unexotic PowerShell (`Write-Host`, `Read-Host`, `Start-Sleep`, `[Environment]::GetEnvironmentVariables()`), and the original author tested on Windows 10 (PowerShell 5.1) and Ubuntu 18.04 (PowerShell 7.2)

Closes #423 (superseding it with this rebased version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr)_