### PR TITLE
Add --unixsocket to listen on a Unix domain socket

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Version 0.5.0 (Apr 26, 2026)
 
+* Added --unixsocket=PATH to listen on a Unix domain socket, in addition to
+  or instead of --address/--port; a leftover socket file from an unclean
+  shutdown is removed automatically (#435, thanks @matvore)
 * Added PowerShell examples (count, greeter, dump-env) alongside the existing
   VBScript/JScript ones — cross-platform via PowerShell Core (#423, thanks
   @kshahar)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ More Features
 *   Very simple install. Just [download](https://github.com/joewalnes/websocketd/wiki/Download-and-install) the single executable for Linux, Mac or Windows and run it. Minimal dependencies, no installers, no package managers, no external libraries. Suitable for development and production servers.
 *   Server side scripts can access details about the WebSocket HTTP request (e.g. remote host, query parameters, cookies, path, etc) via standard [CGI environment variables](https://github.com/joewalnes/websocketd/wiki/Environment-variables).
 *   As well as serving websocket daemons it also includes a static file server and classic CGI server for convenience.
+*   Can listen on a Unix domain socket (`--unixsocket`) instead of, or alongside, a TCP address — useful for exposing websocketd only to processes on the same host, e.g. behind an SSH-forwarded or reverse-proxied socket.
 *   Command line help available via `websocketd --help`.
 *   Includes [WebSocket developer console](https://github.com/joewalnes/websocketd/wiki/Developer-console) to make it easy to test your scripts before you've built a JavaScript frontend.
 *   [Examples in many programming languages](https://github.com/joewalnes/websocketd/tree/master/examples) are available to help you getting started.

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ import (
 
 type Config struct {
 	Addr              []string // TCP addresses to listen on. e.g. ":1234", "1.2.3.4:1234" or "[::1]:1234"
+	UnixSocket        string   // Path of a Unix domain socket to listen on, in addition to (or instead of) Addr
 	MaxForks          int      // Number of allowable concurrent forks
 	LogLevel          libwebsocketd.LogLevel
 	RedirPort         int
@@ -71,6 +72,15 @@ func resolvePort(portFlag int, ssl bool) int {
 		return 443
 	}
 	return 80
+}
+
+// wantsUnixSocketOnly reports whether the user asked to serve exclusively
+// over a Unix domain socket, with no TCP listener at all. This holds only
+// when --unixsocket is given and nothing else implies a TCP listener is
+// wanted (--port, --address, or --redirport); otherwise the Unix socket
+// (if any) is served alongside the usual TCP listener(s).
+func wantsUnixSocketOnly(unixSocket string, portFlag int, addrlist []string, redirPort int) bool {
+	return unixSocket != "" && portFlag == 0 && len(addrlist) == 0 && redirPort == 0
 }
 
 // validateSSL checks that SSL-related flags are consistent.
@@ -166,6 +176,7 @@ func parseCommandLine() *Config {
 
 	// server config options
 	portFlag := flag.Int("port", 0, "HTTP port to listen on")
+	unixSocketFlag := flag.String("unixsocket", "", "Path of a Unix domain socket to listen on, in addition to (or instead of) --address/--port")
 	versionFlag := flag.Bool("version", false, "Print version and exit")
 	licenseFlag := flag.Bool("license", false, "Print license and exit")
 	logLevelFlag := flag.String("loglevel", "access", "Log level, one of: debug, trace, access, info, error, fatal")
@@ -224,9 +235,14 @@ func parseCommandLine() *Config {
 		os.Exit(0)
 	}
 
-	// Resolve port and addresses
-	port := resolvePort(*portFlag, *sslFlag)
-	mainConfig.Addr = resolveAddresses([]string(addrlist), port)
+	// Resolve port and addresses. A bare --unixsocket with no --port,
+	// --address, or --redirport means Unix-socket-only: skip the default
+	// TCP listener entirely rather than also binding ":80".
+	if !wantsUnixSocketOnly(*unixSocketFlag, *portFlag, []string(addrlist), *redirPortFlag) {
+		port := resolvePort(*portFlag, *sslFlag)
+		mainConfig.Addr = resolveAddresses([]string(addrlist), port)
+	}
+	mainConfig.UnixSocket = *unixSocketFlag
 	mainConfig.MaxForks = *maxForksFlag
 	mainConfig.RedirPort = *redirPortFlag
 

--- a/config_test.go
+++ b/config_test.go
@@ -56,6 +56,32 @@ func TestResolveAddresses(t *testing.T) {
 	}
 }
 
+func TestWantsUnixSocketOnly(t *testing.T) {
+	tests := []struct {
+		name       string
+		unixSocket string
+		portFlag   int
+		addrlist   []string
+		redirPort  int
+		want       bool
+	}{
+		{"no unixsocket flag", "", 0, nil, 0, false},
+		{"unixsocket alone", "/tmp/w.sock", 0, nil, 0, true},
+		{"unixsocket with explicit port", "/tmp/w.sock", 8080, nil, 0, false},
+		{"unixsocket with address", "/tmp/w.sock", 0, []string{"127.0.0.1"}, 0, false},
+		{"unixsocket with redirport", "/tmp/w.sock", 0, nil, 8081, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wantsUnixSocketOnly(tt.unixSocket, tt.portFlag, tt.addrlist, tt.redirPort)
+			if got != tt.want {
+				t.Errorf("wantsUnixSocketOnly(%q, %d, %v, %d) = %v, want %v",
+					tt.unixSocket, tt.portFlag, tt.addrlist, tt.redirPort, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateSSL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/help.go
+++ b/help.go
@@ -36,6 +36,15 @@ Options:
                                  Use square brackets to specify IPv6 address.
                                  Default: "" (all)
 
+  --unixsocket=PATH              Path of a Unix domain socket to listen on,
+                                 in addition to (or instead of) --address/
+                                 --port. If it's the only listen option given
+                                 (no --port, --address, or --redirport), no
+                                 TCP listener is started at all. A leftover
+                                 socket file from an unclean shutdown at the
+                                 same path is removed automatically.
+                                 Default: "" (do not listen on a Unix socket)
+
   --sameorigin={true,false}      Restrict (HTTP 403) protocol upgrades if the
                                  Origin header does not match to requested HTTP
                                  Host. Default: false.

--- a/libwebsocketd/handler.go
+++ b/libwebsocketd/handler.go
@@ -95,7 +95,12 @@ type RemoteInfo struct {
 func GetRemoteInfo(remote string, doLookup bool) (*RemoteInfo, error) {
 	addr, port, err := net.SplitHostPort(remote)
 	if err != nil {
-		return nil, err
+		// Not a "host:port" string — this is expected for Unix domain
+		// socket clients, whose peer address has no port (Go reports the
+		// unnamed peer as "@", or "" in other contexts). Use a clear,
+		// stable placeholder rather than leaking that representation, and
+		// don't refuse the connection.
+		return &RemoteInfo{Addr: "unix-socket", Host: "unix-socket", Port: ""}, nil
 	}
 
 	var host string

--- a/libwebsocketd/handler_test.go
+++ b/libwebsocketd/handler_test.go
@@ -99,3 +99,36 @@ func TestParsePathExplicitScript(t *testing.T) {
 		t.Error("filePath")
 	}
 }
+
+func TestGetRemoteInfo(t *testing.T) {
+	t.Run("TCP address", func(t *testing.T) {
+		info, err := GetRemoteInfo("127.0.0.1:54321", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if info.Addr != "127.0.0.1" || info.Port != "54321" {
+			t.Errorf("got Addr=%q Port=%q, want 127.0.0.1/54321", info.Addr, info.Port)
+		}
+	})
+
+	t.Run("Unix domain socket peer", func(t *testing.T) {
+		// Go's net/http sets req.RemoteAddr from the accepted conn's
+		// RemoteAddr().String(); for a Unix listener the client side is
+		// normally unnamed, which Go represents as "@" (or "" in other
+		// contexts) - never a "host:port" string. This must not be
+		// treated as an error - doing so would refuse every connection
+		// over a Unix domain socket.
+		for _, remote := range []string{"@", ""} {
+			info, err := GetRemoteInfo(remote, false)
+			if err != nil {
+				t.Fatalf("unexpected error for unix socket peer %q: %v", remote, err)
+			}
+			if info.Addr != "unix-socket" || info.Host != "unix-socket" {
+				t.Errorf("remote %q: got Addr=%q Host=%q, want unix-socket placeholder", remote, info.Addr, info.Host)
+			}
+			if info.Port != "" {
+				t.Errorf("remote %q: expected empty Port for a unix socket peer, got %q", remote, info.Port)
+			}
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"runtime"
@@ -37,9 +38,26 @@ func logfunc(l *libwebsocketd.LogScope, level libwebsocketd.LogLevel, levelName 
 	l.Mutex.Unlock()
 }
 
-// listenAndServeMutualTLS starts an HTTPS server that requires client certificates
-// verified against the given CA file.
-func listenAndServeMutualTLS(addr, certFile, keyFile, caFile string, log *libwebsocketd.LogScope) error {
+// serve listens on the given network ("tcp" or "unix") and address/path and
+// runs an HTTP(S) server on it, honoring the Ssl/mutual-TLS config. It blocks
+// until the listener errors out.
+func serve(network, address string, config *Config, log *libwebsocketd.LogScope) error {
+	listener, err := net.Listen(network, address)
+	if err != nil {
+		return err
+	}
+	if !config.Ssl {
+		return http.Serve(listener, nil)
+	}
+	if config.SslCaFile != "" {
+		return serveMutualTLS(listener, config.CertFile, config.KeyFile, config.SslCaFile, log)
+	}
+	return (&http.Server{}).ServeTLS(listener, config.CertFile, config.KeyFile)
+}
+
+// serveMutualTLS runs an HTTPS server on the given listener that requires
+// client certificates verified against the given CA file.
+func serveMutualTLS(listener net.Listener, certFile, keyFile, caFile string, log *libwebsocketd.LogScope) error {
 	caCert, err := os.ReadFile(caFile)
 	if err != nil {
 		return fmt.Errorf("failed to read CA file %s: %w", caFile, err)
@@ -49,16 +67,26 @@ func listenAndServeMutualTLS(addr, certFile, keyFile, caFile string, log *libweb
 		return fmt.Errorf("failed to parse CA certificates from %s", caFile)
 	}
 
-	tlsConfig := &tls.Config{
-		ClientAuth: tls.RequireAndVerifyClientCert,
-		ClientCAs:  caCertPool,
-	}
 	server := &http.Server{
-		Addr:      addr,
-		TLSConfig: tlsConfig,
+		TLSConfig: &tls.Config{
+			ClientAuth: tls.RequireAndVerifyClientCert,
+			ClientCAs:  caCertPool,
+		},
 	}
 	log.Info("server", "Mutual TLS enabled (client certs verified against %s)", caFile)
-	return server.ListenAndServeTLS(certFile, keyFile)
+	return server.ServeTLS(listener, certFile, keyFile)
+}
+
+// serveUnixSocket removes a stale socket file left behind by an unclean
+// shutdown (if any) and then serves on it. It only ever removes a path that
+// is actually a socket, never an arbitrary file that happens to be there.
+func serveUnixSocket(path string, config *Config, log *libwebsocketd.LogScope) error {
+	if info, err := os.Stat(path); err == nil && info.Mode()&os.ModeSocket != 0 {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("failed to remove stale socket %s: %w", path, err)
+		}
+	}
+	return serve("unix", path, config, log)
 }
 
 func main() {
@@ -96,9 +124,13 @@ func main() {
 	}
 
 	// Buffered for every possible sender (one listener plus one redirect
-	// server per address) so no goroutine blocks on report; main exits on
-	// the first error received.
-	rejects := make(chan error, len(config.Addr)*2)
+	// server per address, plus the Unix socket listener if any) so no
+	// goroutine blocks on report; main exits on the first error received.
+	rejectCap := len(config.Addr) * 2
+	if config.UnixSocket != "" {
+		rejectCap++
+	}
+	rejects := make(chan error, rejectCap)
 	for _, addrSingle := range config.Addr {
 		log.Info("server", "Starting WebSocket server   : %s", handler.TellURL("ws", addrSingle, "/"))
 		if config.DevConsole {
@@ -106,21 +138,12 @@ func main() {
 		} else if config.StaticDir != "" || config.CgiDir != "" {
 			log.Info("server", "Serving CGI or static files : %s", handler.TellURL("http", addrSingle, "/"))
 		}
-		// ListenAndServe is blocking function. Let's run it in
-		// go routine, reporting result to control channel.
-		// Since it's blocking it'll never return non-error.
+		// serve is a blocking call. Let's run it in a goroutine, reporting
+		// the result to the control channel. Since it's blocking it'll
+		// never return non-error.
 
 		go func(addr string) {
-			if config.Ssl {
-				if config.SslCaFile != "" {
-					// Mutual TLS: require and verify client certificates
-					rejects <- listenAndServeMutualTLS(addr, config.CertFile, config.KeyFile, config.SslCaFile, log)
-				} else {
-					rejects <- http.ListenAndServeTLS(addr, config.CertFile, config.KeyFile, nil)
-				}
-			} else {
-				rejects <- http.ListenAndServe(addr, nil)
-			}
+			rejects <- serve("tcp", addr, config, log)
 		}(addrSingle)
 
 		if config.RedirPort != 0 {
@@ -147,6 +170,12 @@ func main() {
 				rejects <- redir.ListenAndServe()
 			}(addrSingle)
 		}
+	}
+	if config.UnixSocket != "" {
+		log.Info("server", "Starting WebSocket server   : unix socket at %s", config.UnixSocket)
+		go func(path string) {
+			rejects <- serveUnixSocket(path, config, log)
+		}(config.UnixSocket)
 	}
 	err := <-rejects
 	if err != nil {

--- a/qa/integration/helpers_test.go
+++ b/qa/integration/helpers_test.go
@@ -112,7 +112,8 @@ func startServerOpts(t *testing.T, wsFlags []string, mode string, modeArgs ...st
 	return startServerRaw(t, wsFlags, testcmdBin, cmdArgs...)
 }
 
-// startServerRaw starts websocketd with arbitrary flags and command.
+// startServerRaw starts websocketd with arbitrary flags and command,
+// listening on a free TCP port.
 func startServerRaw(t *testing.T, wsFlags []string, command string, cmdArgs ...string) *Server {
 	t.Helper()
 	port := freePort(t)
@@ -126,12 +127,23 @@ func startServerRaw(t *testing.T, wsFlags []string, command string, cmdArgs ...s
 	args = append(args, command)
 	args = append(args, cmdArgs...)
 
+	s := startServerRawArgs(t, args)
+	s.Port = port
+	waitForPort(t, port, 10*time.Second)
+	return s
+}
+
+// startServerRawArgs starts websocketd with a fully custom argument list —
+// e.g. for --unixsocket-only tests, which must not have a --port/--address
+// injected. Callers are responsible for waiting on readiness themselves
+// (waitForPort, waitForSocket, ...).
+func startServerRawArgs(t *testing.T, args []string) *Server {
+	t.Helper()
 	cmd := exec.Command(websocketdBin, args...)
 
 	s := &Server{
-		t:    t,
-		Port: port,
-		cmd:  cmd,
+		t:   t,
+		cmd: cmd,
 	}
 
 	// Capture each stream separately; cmd.Wait joins exec's copier
@@ -152,7 +164,6 @@ func startServerRaw(t *testing.T, wsFlags []string, command string, cmdArgs ...s
 		}
 	})
 
-	waitForPort(t, port, 10*time.Second)
 	return s
 }
 

--- a/qa/integration/issue435_test.go
+++ b/qa/integration/issue435_test.go
@@ -1,0 +1,110 @@
+package integration
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Tests for #435: serving over a Unix domain socket via --unixsocket.
+
+// dialUnixSocket connects a WSClient to a websocketd instance listening on a
+// Unix domain socket. The URL host is ignored by the custom dialer; only the
+// path matters.
+func dialUnixSocket(t *testing.T, sockPath, path string) *WSClient {
+	t.Helper()
+	dialer := websocket.Dialer{
+		NetDial: func(network, addr string) (net.Conn, error) {
+			return net.Dial("unix", sockPath)
+		},
+		HandshakeTimeout: 5 * time.Second,
+	}
+	conn, _, err := dialer.Dial("ws://unix-socket"+path, nil)
+	if err != nil {
+		t.Fatalf("failed to dial unix socket %s: %v", sockPath, err)
+	}
+	conn.SetReadLimit(10 * 1024 * 1024)
+	ws := &WSClient{t: t, conn: conn}
+	t.Cleanup(func() { conn.Close() })
+	return ws
+}
+
+// waitForSocket polls until a Unix domain socket file is dialable.
+func waitForSocket(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if conn, err := net.Dial("unix", path); err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for unix socket %s", path)
+}
+
+func skipUnixSocketOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		// AF_UNIX support on Windows is recent and CI coverage for it is
+		// thin; skip execution here rather than risk a flaky CI signal.
+		// The --unixsocket flag itself is not restricted to non-Windows.
+		t.Skip("skipping Unix domain socket test on windows")
+	}
+}
+
+func TestIssue435_UnixSocketEcho(t *testing.T) {
+	skipUnixSocketOnWindows(t)
+	t.Parallel()
+
+	sockPath := filepath.Join(t.TempDir(), "websocketd.sock")
+	args := []string{"--unixsocket=" + sockPath, "--loglevel=access", testcmdBin, "echo"}
+	cmd := startServerRawArgs(t, args)
+	waitForSocket(t, sockPath, 10*time.Second)
+
+	ws := dialUnixSocket(t, sockPath, "/")
+	ws.Send("hello over uds")
+	ws.ExpectMessage("hello over uds")
+
+	if strings.Contains(cmd.Stdout(), "ws://") {
+		t.Error("expected no TCP listener log line when only --unixsocket is set")
+	}
+	if !strings.Contains(cmd.Stdout(), "unix socket at "+sockPath) {
+		t.Errorf("expected a log line announcing the unix socket, got:\n%s", cmd.Stdout())
+	}
+}
+
+func TestIssue435_StaleSocketCleanup(t *testing.T) {
+	skipUnixSocketOnWindows(t)
+	t.Parallel()
+
+	sockPath := filepath.Join(t.TempDir(), "websocketd.sock")
+
+	// Simulate a leftover socket file from an unclean shutdown (e.g. a
+	// killed process, which never gets to run its own cleanup). A graceful
+	// Close() would auto-unlink the file, so disable that explicitly to
+	// leave the file behind, same as a hard kill would.
+	stale, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("failed to create stale socket: %v", err)
+	}
+	stale.(*net.UnixListener).SetUnlinkOnClose(false)
+	stale.Close()
+	if _, err := os.Stat(sockPath); err != nil {
+		t.Fatalf("expected stale socket file to remain on disk: %v", err)
+	}
+
+	args := []string{"--unixsocket=" + sockPath, "--loglevel=access", testcmdBin, "echo"}
+	startServerRawArgs(t, args)
+	waitForSocket(t, sockPath, 10*time.Second)
+
+	ws := dialUnixSocket(t, sockPath, "/")
+	ws.Send("still works")
+	ws.ExpectMessage("still works")
+}

--- a/qa/integration/issue435_test.go
+++ b/qa/integration/issue435_test.go
@@ -59,11 +59,26 @@ func skipUnixSocketOnWindows(t *testing.T) {
 	}
 }
 
+// shortSocketPath returns a socket path short enough to survive macOS's
+// 104-byte sockaddr_un.sun_path limit. t.TempDir() is unusable here: on
+// macOS CI, $TMPDIR is already a long random path, and nesting the test
+// name and a "/001/" subdir under it routinely blows past the limit
+// (bind: invalid argument). /tmp itself is always short.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "wsd")
+	if err != nil {
+		t.Fatalf("failed to create temp dir for socket: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "s.sock")
+}
+
 func TestIssue435_UnixSocketEcho(t *testing.T) {
 	skipUnixSocketOnWindows(t)
 	t.Parallel()
 
-	sockPath := filepath.Join(t.TempDir(), "websocketd.sock")
+	sockPath := shortSocketPath(t)
 	args := []string{"--unixsocket=" + sockPath, "--loglevel=access", testcmdBin, "echo"}
 	cmd := startServerRawArgs(t, args)
 	waitForSocket(t, sockPath, 10*time.Second)
@@ -84,7 +99,7 @@ func TestIssue435_StaleSocketCleanup(t *testing.T) {
 	skipUnixSocketOnWindows(t)
 	t.Parallel()
 
-	sockPath := filepath.Join(t.TempDir(), "websocketd.sock")
+	sockPath := shortSocketPath(t)
 
 	// Simulate a leftover socket file from an unclean shutdown (e.g. a
 	// killed process, which never gets to run its own cleanup). A graceful

--- a/qa/plans/03-cli-configuration.md
+++ b/qa/plans/03-cli-configuration.md
@@ -401,3 +401,25 @@ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 1 -nodes 
 3. `websocketd --port=8080 --binary=false cat`
 
 **Expected Result**: --binary and --binary=true enable binary mode. --binary=false uses text mode.
+
+---
+
+## CLI-032: --unixsocket Unix Domain Socket
+
+**Priority**: P2
+
+**Steps**:
+1. `websocketd --unixsocket=/tmp/websocketd.sock cat` (no --port/--address)
+2. Connect a WebSocket client dialing the Unix socket path directly
+   (e.g. `curl --unix-socket /tmp/websocketd.sock` or a client with a
+   custom dialer) rather than a TCP address
+3. Restart the same command after killing it with `SIGKILL` (simulating an
+   unclean shutdown that leaves the socket file behind)
+4. `websocketd --port=8080 --unixsocket=/tmp/websocketd.sock cat` (combined
+   with a TCP listener)
+
+**Expected Result**: Step 1 starts with no TCP listener at all (only the
+Unix socket log line appears). Step 2 connects and echoes normally. Step 3
+succeeds — the stale socket file is removed automatically rather than
+failing with "address already in use". Step 4 serves both listeners
+simultaneously.

--- a/release/websocketd.man
+++ b/release/websocketd.man
@@ -29,6 +29,11 @@ HTTP port to listen on.
 Address to bind to (multiple options allowed). Use square brackets to specify IPv6 address. Default: "" (all)
 .RE
 .PP
+\-\-unixsocket=PATH
+.RS 4
+Path of a Unix domain socket to listen on, in addition to (or instead of) \-\-address/\-\-port. If it's the only listen option given (no \-\-port, \-\-address, or \-\-redirport), no TCP listener is started at all. A leftover socket file from an unclean shutdown at the same path is removed automatically. Default: "" (do not listen on a Unix socket)
+.RE
+.PP
 \-\-sameorigin={true,false}
 .RS 4
 Restrict (HTTP 403) protocol upgrades if the Origin header does not match to requested HTTP Host. Default: false.


### PR DESCRIPTION
## Summary

Rebase and rework of #435 (by @matvore) onto current master.

- New `--unixsocket=PATH` flag (renamed from the original `--uds` — this codebase's other flags don't use hyphens: `--staticdir`, `--cgidir`, `--reverselookup`, `--sslcert`, etc., so `--unixsocket` fits the convention better and reads more clearly on its own).
- Serves alongside `--address`/`--port` by default. Given alone (no `--port`, `--address`, or `--redirport`), no TCP listener is started at all — useful for exposing websocketd only to processes on the same host, e.g. behind an SSH-forwarded or reverse-proxied socket (the original author's use case).
- A stale socket file left behind by an unclean shutdown (a killed process never gets to unlink it) is now removed automatically before binding, instead of failing with "address already in use".

## What changed from the original PR

The original PR predates the mutual-TLS support (`--sslca`) added to `main.go` since, and touches the same serving loop, so a straight rebase would conflict. Instead:

- **Unified serving helper.** TCP and Unix listeners now go through one `serve(network, address, config, log)` function that also handles plain HTTP, TLS, and mutual TLS — replacing the old inline `Ssl`/`SslCaFile` branch that only existed for TCP. This also simplified `serveMutualTLS` to take a `net.Listener` instead of an address string.
- **`GetRemoteInfo` fix moved to the source.** A Unix socket peer has no `host:port` to parse (Go reports it as `"@"`, confirmed by testing — not the empty string I initially expected), which made `GetRemoteInfo` return an error and refuse every connection. Fixed in `GetRemoteInfo` itself (now returns a stable `"unix-socket"` placeholder) rather than special-cased at the `handler.go` call site, so every caller benefits and `REMOTE_ADDR`/`REMOTE_HOST` show something readable instead of `@`.
- **Stale-socket cleanup** — not present in the original PR. Without it, restarting after a crash fails with "address already in use" until the file is manually removed.
- **Tests**: unit tests for `wantsUnixSocketOnly` and `GetRemoteInfo`'s new Unix-socket branch, plus two integration tests (a real WebSocket echo round-trip over a socket, and stale-socket recovery after a simulated `SIGKILL`). Added a QA plan entry (CLI-032) and docs (`--help`, README, man page).

## Testing

- `go build`/`go vet`/`gofmt -l .`/`staticcheck` all clean
- `go test ./... -race` passes, including the two new integration tests
- Manually verified end-to-end beyond what the tests cover: a real `gorilla/websocket` client dialing the socket directly got a full handshake + echo through `/bin/cat`; confirmed via log output that unixsocket-only mode binds no TCP listener at all; confirmed a socket file left behind by `kill -9` is cleaned up and the next start succeeds

Closes #435 (superseding it with this rebased and extended version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr)_