### PR TITLE
Add --passstderr to forward STDERR to WebSocket clients as tagged JSON

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 Version 0.5.0 (Apr 26, 2026)
 
+* Added --passstderr to forward STDERR to WebSocket clients, tagged
+  alongside STDOUT as JSON ({"stream":"stdout"|"stderr","data":"..."});
+  STDERR is still logged server-side either way. Mutually exclusive with
+  --binary (#459, thanks @Formatted)
 * Added --unixsocket=PATH to listen on a Unix domain socket, in addition to
   or instead of --address/--port; a leftover socket file from an unclean
   shutdown is removed automatically (#435, thanks @matvore)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ More Features
 *   Server side scripts can access details about the WebSocket HTTP request (e.g. remote host, query parameters, cookies, path, etc) via standard [CGI environment variables](https://github.com/joewalnes/websocketd/wiki/Environment-variables).
 *   As well as serving websocket daemons it also includes a static file server and classic CGI server for convenience.
 *   Can listen on a Unix domain socket (`--unixsocket`) instead of, or alongside, a TCP address — useful for exposing websocketd only to processes on the same host, e.g. behind an SSH-forwarded or reverse-proxied socket.
+*   STDERR can optionally be forwarded to WebSocket clients (`--passstderr`), tagged alongside STDOUT as JSON so a client can tell the two apart.
 *   Command line help available via `websocketd --help`.
 *   Includes [WebSocket developer console](https://github.com/joewalnes/websocketd/wiki/Developer-console) to make it easy to test your scripts before you've built a JavaScript frontend.
 *   [Examples in many programming languages](https://github.com/joewalnes/websocketd/tree/master/examples) are available to help you getting started.

--- a/config.go
+++ b/config.go
@@ -97,6 +97,17 @@ func validateSSL(ssl bool, certFile, keyFile string) error {
 	return nil
 }
 
+// validateBinaryPassStderr checks that --binary and --passstderr aren't both
+// set. Tagging binary chunks as JSON isn't implemented (--passstderr always
+// reads line by line), so combining the two would silently discard --binary
+// instead of behaving as either flag alone.
+func validateBinaryPassStderr(binary, passStderr bool) error {
+	if binary && passStderr {
+		return fmt.Errorf("please only specify one of --binary and --passstderr")
+	}
+	return nil
+}
+
 // buildParentEnv constructs the filtered parent environment variable list.
 func buildParentEnv(passenv string) []string {
 	env := make([]string, 0)
@@ -191,6 +202,7 @@ func parseCommandLine() *Config {
 
 	// lib config options
 	binaryFlag := flag.Bool("binary", false, "Set websocketd to experimental binary mode (default is line by line)")
+	passStderrFlag := flag.Bool("passstderr", false, "Forward STDERR to WebSocket clients as tagged JSON messages, alongside tagged STDOUT (mutually exclusive with --binary)")
 	reverseLookupFlag := flag.Bool("reverselookup", false, "Perform reverse DNS lookups on remote clients")
 	scriptDirFlag := flag.String("dir", "", "Base directory for WebSocket scripts")
 	staticDirFlag := flag.String("staticdir", "", "Serve static content from this directory over HTTP")
@@ -262,6 +274,12 @@ func parseCommandLine() *Config {
 	mainConfig.CertFile = *sslCert
 	mainConfig.KeyFile = *sslKey
 
+	// Validate --binary / --passstderr
+	if err := validateBinaryPassStderr(*binaryFlag, *passStderrFlag); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+
 	// Build lib config
 	config.Headers = []string(headers)
 	config.HeadersWs = []string(headersWs)
@@ -269,6 +287,7 @@ func parseCommandLine() *Config {
 	config.CloseMs = *closeMsFlag
 	config.PingInterval = time.Duration(*pingMsFlag) * time.Millisecond
 	config.Binary = *binaryFlag
+	config.PassStderr = *passStderrFlag
 	config.ReverseLookup = *reverseLookupFlag
 	config.Ssl = *sslFlag
 	config.SslCaFile = *sslCaFlag

--- a/config_test.go
+++ b/config_test.go
@@ -82,6 +82,28 @@ func TestWantsUnixSocketOnly(t *testing.T) {
 	}
 }
 
+func TestValidateBinaryPassStderr(t *testing.T) {
+	tests := []struct {
+		name       string
+		binary     bool
+		passStderr bool
+		wantErr    bool
+	}{
+		{"neither set", false, false, false},
+		{"binary only", true, false, false},
+		{"passstderr only", false, true, false},
+		{"both set", true, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBinaryPassStderr(tt.binary, tt.passStderr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateBinaryPassStderr(%v, %v) error = %v, wantErr %v", tt.binary, tt.passStderr, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateSSL(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/help.go
+++ b/help.go
@@ -78,6 +78,13 @@ Options:
                                  browser are immediately flushed to the process.
                                  Default: false
 
+  --passstderr                   Forward the process's STDERR to WebSocket
+                                 clients, tagged (alongside STDOUT) as JSON:
+                                 {"stream":"stdout","data":"..."} or
+                                 {"stream":"stderr","data":"..."}. STDERR is
+                                 still logged server-side either way. Cannot
+                                 be combined with --binary. Default: false
+
   --reverselookup={true,false}   Perform DNS reverse lookups on remote clients.
                                  Default: false
 

--- a/libwebsocketd/config.go
+++ b/libwebsocketd/config.go
@@ -22,6 +22,7 @@ type Config struct {
 
 	// settings
 	Binary         bool     // Use binary communication (send data in chunks they are read from process)
+	PassStderr     bool     // Forward STDERR to WebSocket clients as tagged JSON messages, alongside tagged STDOUT
 	ReverseLookup  bool     // Perform reverse DNS lookups on hostnames (useful, but slower).
 	Ssl            bool     // websocketd works with --ssl which means TLS is in use
 	SslCaFile      string   // CA certificate file for client certificate verification (mutual TLS).

--- a/libwebsocketd/handler.go
+++ b/libwebsocketd/handler.go
@@ -77,7 +77,7 @@ func (wsh *WebsocketdHandler) accept(ws *websocket.Conn, log *LogScope) {
 	log.Associate("pid", strconv.Itoa(launched.cmd.Process.Pid))
 
 	binary := wsh.server.Config.Binary
-	process := NewProcessEndpoint(launched, binary, log)
+	process := NewProcessEndpoint(launched, binary, log, wsh.server.Config.PassStderr)
 	if cms := wsh.server.Config.CloseMs; cms != 0 {
 		process.closetime += time.Duration(cms) * time.Millisecond
 	}

--- a/libwebsocketd/process_endpoint.go
+++ b/libwebsocketd/process_endpoint.go
@@ -7,6 +7,7 @@ package libwebsocketd
 
 import (
 	"bufio"
+	"encoding/json"
 	"io"
 	"os"
 	"sync"
@@ -15,22 +16,25 @@ import (
 )
 
 type ProcessEndpoint struct {
-	process   *LaunchedProcess
-	closetime time.Duration
-	output    chan []byte
-	done      chan struct{}
-	doneOnce  sync.Once
-	log       *LogScope
-	bin       bool
+	process    *LaunchedProcess
+	closetime  time.Duration
+	output     chan []byte
+	done       chan struct{}
+	doneOnce   sync.Once
+	log        *LogScope
+	bin        bool
+	passStderr bool
+	wg         sync.WaitGroup
 }
 
-func NewProcessEndpoint(process *LaunchedProcess, bin bool, log *LogScope) *ProcessEndpoint {
+func NewProcessEndpoint(process *LaunchedProcess, bin bool, log *LogScope, passStderr bool) *ProcessEndpoint {
 	return &ProcessEndpoint{
-		process: process,
-		output:  make(chan []byte),
-		done:    make(chan struct{}),
-		log:     log,
-		bin:     bin,
+		process:    process,
+		output:     make(chan []byte),
+		done:       make(chan struct{}),
+		log:        log,
+		bin:        bin,
+		passStderr: passStderr,
 	}
 }
 
@@ -100,12 +104,29 @@ func (pe *ProcessEndpoint) Send(msg []byte) bool {
 }
 
 func (pe *ProcessEndpoint) StartReading() {
+	if pe.passStderr {
+		// Both streams feed the same output channel, tagged by source, so
+		// it must close only once both readers are done - never while
+		// either might still send. (--binary is rejected together with
+		// --passstderr at config-validation time, so only line-based
+		// reading is needed here.)
+		pe.wg.Add(2)
+		go pe.readStdoutTagged()
+		go pe.readStderrTagged()
+		go pe.closeOutputWhenDone()
+		return
+	}
 	go pe.logStderr()
 	if pe.bin {
 		go pe.readBinaryOutput()
 	} else {
 		go pe.readTextOutput()
 	}
+}
+
+func (pe *ProcessEndpoint) closeOutputWhenDone() {
+	pe.wg.Wait()
+	close(pe.output)
 }
 
 func (pe *ProcessEndpoint) readTextOutput() {
@@ -144,6 +165,64 @@ func (pe *ProcessEndpoint) readBinaryOutput() {
 		}
 		select {
 		case pe.output <- append(make([]byte, 0, n), buf[:n]...): // cloned buffer
+		case <-pe.done:
+			return
+		}
+	}
+}
+
+// taggedMessage is the JSON envelope sent to WebSocket clients when
+// --passstderr is enabled, so they can distinguish the two streams.
+type taggedMessage struct {
+	Stream string `json:"stream"`
+	Data   string `json:"data"`
+}
+
+func tagMessage(stream string, data []byte) []byte {
+	// json.Marshal cannot fail here: the struct holds only plain strings
+	// (invalid UTF-8 is replaced, not rejected).
+	msg, _ := json.Marshal(taggedMessage{Stream: stream, Data: string(data)})
+	return msg
+}
+
+func (pe *ProcessEndpoint) readStdoutTagged() {
+	defer pe.wg.Done()
+	bufin := bufio.NewReader(pe.process.stdout)
+	for {
+		buf, err := bufin.ReadBytes('\n')
+		if err != nil {
+			if err != io.EOF {
+				pe.log.Error("process", "Unexpected error while reading STDOUT from process: %s", err)
+			} else {
+				pe.log.Debug("process", "Process STDOUT closed")
+			}
+			break
+		}
+		select {
+		case pe.output <- tagMessage("stdout", trimEOL(buf)):
+		case <-pe.done:
+			return
+		}
+	}
+}
+
+func (pe *ProcessEndpoint) readStderrTagged() {
+	defer pe.wg.Done()
+	bufstderr := bufio.NewReader(pe.process.stderr)
+	for {
+		buf, err := bufstderr.ReadSlice('\n')
+		if err != nil {
+			if err != io.EOF {
+				pe.log.Error("process", "Unexpected error while reading STDERR from process: %s", err)
+			} else {
+				pe.log.Debug("process", "Process STDERR closed")
+			}
+			break
+		}
+		line := trimEOL(buf)
+		pe.log.Error("stderr", "%s", string(line)) // still logged server-side, same as without --passstderr
+		select {
+		case pe.output <- tagMessage("stderr", line):
 		case <-pe.done:
 			return
 		}

--- a/libwebsocketd/process_endpoint_test.go
+++ b/libwebsocketd/process_endpoint_test.go
@@ -6,6 +6,7 @@
 package libwebsocketd
 
 import (
+	"encoding/json"
 	"runtime"
 	"testing"
 	"time"
@@ -32,6 +33,20 @@ func echoProcess(t *testing.T) *LaunchedProcess {
 	return lp
 }
 
+// stdoutStderrProcess launches a short-lived process that writes one line to
+// each of STDOUT and STDERR, then exits.
+func stdoutStderrProcess(t *testing.T, stdoutLine, stderrLine string) *LaunchedProcess {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses /bin/sh")
+	}
+	lp, err := launchCmd("/bin/sh", []string{"-c", "echo " + stdoutLine + "; echo " + stderrLine + " >&2"}, nil)
+	if err != nil {
+		t.Fatalf("launchCmd failed: %v", err)
+	}
+	return lp
+}
+
 // TestTerminateUnblocksParkedReader reproduces the goroutine leak that occurs
 // when the relay stops draining Output() (e.g. the WebSocket send failed) while
 // the stdout reader is parked on the unbuffered output channel send. Terminate
@@ -45,7 +60,7 @@ func TestTerminateUnblocksParkedReader(t *testing.T) {
 		t.Run(mode.name, func(t *testing.T) {
 			before := runtime.NumGoroutine()
 
-			pe := NewProcessEndpoint(echoProcess(t), mode.bin, quietLogScope())
+			pe := NewProcessEndpoint(echoProcess(t), mode.bin, quietLogScope(), false)
 			pe.StartReading()
 
 			// Never drain pe.Output(): the reader picks up "hello" and parks
@@ -67,5 +82,89 @@ func TestTerminateUnblocksParkedReader(t *testing.T) {
 			t.Fatalf("goroutine leak: %d goroutines before, %d after Terminate (stdout reader parked on output send?)",
 				before, runtime.NumGoroutine())
 		})
+	}
+}
+
+// TestTerminateUnblocksParkedReader_PassStderr is the --passstderr mirror of
+// TestTerminateUnblocksParkedReader: readStdoutTagged and readStderrTagged
+// must each observe Terminate's done signal and exit, the same as the plain
+// text/binary readers.
+func TestTerminateUnblocksParkedReader_PassStderr(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	pe := NewProcessEndpoint(stdoutStderrProcess(t, "out1", "err1"), false, quietLogScope(), true)
+	pe.StartReading()
+
+	// Never drain pe.Output(): both taggers read their one line and park on
+	// the channel send, exactly like a relay whose peer went away.
+	time.Sleep(100 * time.Millisecond)
+
+	pe.Terminate()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= before {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("goroutine leak: %d goroutines before, %d after Terminate (tagged reader parked on output send?)",
+		before, runtime.NumGoroutine())
+}
+
+func TestPassStderrTagging(t *testing.T) {
+	pe := NewProcessEndpoint(stdoutStderrProcess(t, "stdout-msg", "stderr-msg"), false, quietLogScope(), true)
+	pe.StartReading()
+	defer pe.Terminate()
+
+	collected := map[string]string{}
+	timeout := time.After(5 * time.Second)
+	for len(collected) < 2 {
+		select {
+		case data, ok := <-pe.Output():
+			if !ok {
+				t.Fatalf("output channel closed early with %d/2 messages: %v", len(collected), collected)
+			}
+			var envelope taggedMessage
+			if err := json.Unmarshal(data, &envelope); err != nil {
+				t.Fatalf("failed to parse JSON message %q: %v", data, err)
+			}
+			collected[envelope.Stream] = envelope.Data
+		case <-timeout:
+			t.Fatalf("timeout waiting for messages, got %d/2: %v", len(collected), collected)
+		}
+	}
+
+	if collected["stdout"] != "stdout-msg" {
+		t.Errorf("stdout = %q, want %q", collected["stdout"], "stdout-msg")
+	}
+	if collected["stderr"] != "stderr-msg" {
+		t.Errorf("stderr = %q, want %q", collected["stderr"], "stderr-msg")
+	}
+
+	// The channel must close only after both readers are done, never while
+	// one might still send.
+	select {
+	case _, ok := <-pe.Output():
+		if ok {
+			t.Fatal("expected no further messages")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for output channel to close")
+	}
+}
+
+func TestPassStderrTagMessageEscaping(t *testing.T) {
+	msg := tagMessage("stderr", []byte(`quote " backslash \ newline`+"\n"+"tab\ttab"))
+	var envelope taggedMessage
+	if err := json.Unmarshal(msg, &envelope); err != nil {
+		t.Fatalf("tagMessage produced invalid JSON %q: %v", msg, err)
+	}
+	if envelope.Stream != "stderr" {
+		t.Errorf("stream = %q, want %q", envelope.Stream, "stderr")
+	}
+	want := "quote \" backslash \\ newline\ntab\ttab"
+	if envelope.Data != want {
+		t.Errorf("data = %q, want %q", envelope.Data, want)
 	}
 }

--- a/qa/integration/issue459_test.go
+++ b/qa/integration/issue459_test.go
@@ -1,0 +1,75 @@
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for #459: forward STDERR to WebSocket clients via --passstderr.
+
+func TestIssue459_PassStderrTagsBothStreams(t *testing.T) {
+	t.Parallel()
+	s := startServerOpts(t, []string{"--passstderr"}, "stderr")
+	ws := s.Connect("/")
+	defer ws.Close()
+
+	collected := map[string]string{}
+	deadline := time.Now().Add(5 * time.Second)
+	for len(collected) < 2 && time.Now().Before(deadline) {
+		msg, err := ws.RecvTimeout(1 * time.Second)
+		if err != nil {
+			continue
+		}
+		var envelope struct {
+			Stream string `json:"stream"`
+			Data   string `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(msg), &envelope); err != nil {
+			t.Fatalf("expected tagged JSON message, got %q: %v", msg, err)
+		}
+		collected[envelope.Stream] = envelope.Data
+	}
+
+	if collected["stdout"] != "stdout line" {
+		t.Errorf("stdout = %q, want %q", collected["stdout"], "stdout line")
+	}
+	if collected["stderr"] != "stderr line" {
+		t.Errorf("stderr = %q, want %q", collected["stderr"], "stderr line")
+	}
+
+	// The child's stderr must still reach websocketd's own log (on stdout),
+	// same as without --passstderr - the flag adds client forwarding, it
+	// doesn't replace server-side logging.
+	logDeadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(s.Stdout(), "stderr line") && time.Now().Before(logDeadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if !strings.Contains(s.Stdout(), "stderr line") {
+		t.Error("expected child stderr to still be logged server-side with --passstderr")
+	}
+}
+
+func TestIssue459_NoPassStderrByDefault(t *testing.T) {
+	// Without --passstderr, behavior is unchanged: only stdout reaches the
+	// client, untagged (not wrapped in the {"stream":...} envelope).
+	t.Parallel()
+	s := startServer(t, "stderr")
+	ws := s.Connect("/")
+	defer ws.Close()
+
+	ws.ExpectMessage("stdout line")
+	ws.ExpectClosed()
+}
+
+func TestIssue459_BinaryAndPassStderrRejected(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runWebsocketd(t, "--port=0", "--binary", "--passstderr", testcmdBin, "echo")
+	if exitCode == 0 {
+		t.Fatal("expected non-zero exit combining --binary and --passstderr")
+	}
+	if !strings.Contains(stderr, "--binary") || !strings.Contains(stderr, "--passstderr") {
+		t.Errorf("expected error mentioning both flags, got stderr: %q", stderr)
+	}
+}

--- a/qa/plans/02-process-management.md
+++ b/qa/plans/02-process-management.md
@@ -366,3 +366,22 @@ while IFS= read -r line; do echo "$line"; done
 2. Open many connections (50+)
 
 **Expected Result**: All connections are accepted (0 means no limit). System resources are the only constraint.
+
+---
+
+## PROC-022: --passstderr Forwards STDERR to Clients
+
+**Priority**: P2
+
+**Steps**:
+1. Start websocketd: `websocketd --port=8080 --passstderr ./script-writing-to-both.sh`
+2. Connect and collect messages
+3. Repeat without `--passstderr`
+4. `websocketd --port=8080 --binary --passstderr cat`
+
+**Expected Result**: With `--passstderr`, both STDOUT and STDERR lines arrive
+as JSON messages tagged `{"stream":"stdout",...}` / `{"stream":"stderr",...}`;
+STDERR is still written to the server log either way. Without the flag,
+only STDOUT reaches the client, untagged (unchanged from prior versions).
+Step 4 fails at startup with an error naming both flags — `--binary` and
+`--passstderr` are mutually exclusive.

--- a/release/websocketd.man
+++ b/release/websocketd.man
@@ -69,6 +69,11 @@ Lists environment variables allowed to be passed to executed scripts. Does not w
 Switches communication to binary: process reads are sent to the browser as blobs and all reads from the browser are immediately flushed to the process. Default: false
 .RE
 .PP
+\-\-passstderr
+.RS 4
+Forward the process's STDERR to WebSocket clients, tagged (alongside STDOUT) as JSON: {"stream":"stdout","data":"..."} or {"stream":"stderr","data":"..."}. STDERR is still logged server-side either way. Cannot be combined with \-\-binary. Default: false
+.RE
+.PP
 \-\-reverselookup={true,false}
 .RS 4
 Perform DNS reverse lookups on remote clients. Default: false


### PR DESCRIPTION
## Summary

Rebase and rework of #459 (by @Formatted) onto current master.

Forwards STDERR to WebSocket clients as tagged JSON, alongside tagged STDOUT, so a client can tell the two apart:
```json
{"stream":"stdout","data":"..."}
{"stream":"stderr","data":"..."}
```
STDERR is still logged server-side either way, same as without the flag. Addresses #403 (open since 2021).

## What changed from the original PR

- **Integrated with the goroutine-leak fix.** The tagged stdout/stderr readers now `select{}` on the output send against `Terminate`'s done signal, same as the plain text/binary readers added by an earlier PR. The original PR's readers predate that fix and would have reintroduced the same class of leak (a reader parked forever on a channel send after the relay stops draining). Verified by temporarily reverting just that part and watching the new regression test fail (3 leaked goroutines), then restoring it.
- **`--binary` and `--passstderr` are now mutually exclusive**, rejected at startup with a clear error. The original PR's `StartReading` silently dropped `--binary` whenever `--passstderr` was set (it checked `passStderr` before `bin`), which would silently corrupt binary output instead of erroring. Tagging arbitrary binary chunks as JSON string data isn't implemented, so refusing the combination is safer than a partial implementation.
- **JSON encoding via `encoding/json`** (a small `taggedMessage` struct) instead of a hand-rolled escaper, so it can't emit invalid JSON for control characters or non-UTF8 bytes the original escaper didn't handle.
- **Tests**: a `--binary`/`--passstderr` validation unit test, a goroutine-leak regression test mirroring the process-endpoint one, an integration test asserting the tagged JSON over a real WebSocket connection (and that STDERR still reaches the server log), and a QA plan entry.

## Testing

- `go build`/`go vet`/`gofmt -l .`/`staticcheck` all clean
- `go test ./... -race` passes
- Verified the leak fix is load-bearing: reverted just the `select{}`/done-channel part of the tagged readers, confirmed `TestTerminateUnblocksParkedReader_PassStderr` fails (goroutine leak detected), restored it and confirmed it passes

Closes #459 (superseding it with this rebased and extended version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr)_