### PR TITLE
Run each benchmark scenario 3x and report the median; bump alert threshold

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -58,9 +58,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ github.event_name == 'push' }}
           comment-on-alert: true
-          alert-threshold: '115%'
-          # Advisory only: single k6 runs on shared runners are too noisy
-          # for a hard merge gate; the alert comment still flags regressions.
+          # run.sh now takes the median of 3 runs per scenario, which cuts
+          # a lot of shared-runner noise on its own; a small threshold bump
+          # on top accounts for what's left. Still advisory, not a gate.
+          alert-threshold: '125%'
+          # Advisory only: k6 runs on shared runners are too noisy for a
+          # hard merge gate; the alert comment still flags regressions.
           fail-on-alert: false
           benchmark-data-dir-path: dev/bench
           alert-comment-cc-users: '@joewalnes'

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 Version 0.5.0 (Apr 26, 2026)
 
+* Benchmark suite now runs each scenario 3 times and reports the median
+  (bench/run.sh --runs=N), cutting shared-CI-runner noise that was
+  producing false-positive regression alerts; alert threshold raised
+  from 15% to 25% to match. Also fixed the CI Integration docs, which
+  still claimed regressions block merges (they've been advisory-only
+  since the earlier k6-install fix)
 * Added --passstderr to forward STDERR to WebSocket clients, tagged
   alongside STDOUT as JSON ({"stream":"stdout"|"stderr","data":"..."});
   STDERR is still logged server-side either way. Mutually exclusive with

--- a/bench/README.md
+++ b/bench/README.md
@@ -52,14 +52,20 @@ The benchmark tool works with any websocketd binary — use it to compare versio
 
 ## Output
 
+Each scenario runs 3 times by default (`--runs=N` to change) and the results
+are merged into a single median before reporting — see "Repeated Runs"
+below.
+
 ```
 bench/results/
   meta.json                    # Version, git hash, timestamp, OS
-  *_summary.json               # k6 summary per scenario
-  *_k6.json                    # k6 detailed output per scenario
-  *_server.ndjson              # Server metrics per scenario
+  *_summary.json               # Median across all runs of this scenario
+  *_summary.run{N}.json        # k6 summary for one run
+  *_k6.run{N}.json             # k6 detailed output for one run
+  *_server.ndjson              # The run whose peak RSS is closest to the median
+  *_server.run{N}.ndjson       # Server metrics for one run
   report.html                  # Visual report (open in browser)
-  benchmark-data.json          # CI regression detection format
+  benchmark-data.json          # CI regression detection format, from the median
 ```
 
 ## Running a Subset
@@ -68,14 +74,33 @@ bench/results/
 ./bench/run.sh ./websocketd --scenarios=echo_latency,echo_throughput
 ```
 
+## Repeated Runs
+
+A single k6 run on shared hardware (like GitHub Actions runners) can vary
+20%+ between otherwise-identical commits, which used to produce false
+regression alerts. `run.sh` now repeats each scenario 3 times (`--runs=N`
+to change; `--runs=1` restores the old single-run behavior) and reports
+the median:
+
+- **k6 metrics** (latency, throughput, etc.): the per-metric median across
+  all N runs' `--summary-export` output.
+- **Server RSS/FDs**: rather than merge the time series (which wouldn't
+  produce a real one), the run whose peak RSS is closest to the group's
+  median is used as-is, so the report's memory chart still shows one
+  genuine, representative run.
+
+If any of the N runs fails outright, the whole scenario is reported as
+failed rather than silently averaging over fewer, "surviving" runs.
+
 ## CI Integration
 
 The `bench.yml` GitHub Actions workflow:
-- Runs all scenarios on every push to master and on PRs
+- Runs all scenarios (median of 3 runs each) on every push to master and on PRs
 - Uploads `report.html` as a workflow artifact
 - Tracks metrics over time on [the dashboard](https://websocketd.com/dev/bench/)
-- Posts comparison comments on PRs
-- Blocks merges on >15% regression
+- Posts comparison comments on PRs when a metric regresses >25%; this is
+  advisory only and does not block merging (shared-runner noise is too
+  high for a hard gate)
 
 ## Design Decisions
 

--- a/bench/lib/merge-runs.py
+++ b/bench/lib/merge-runs.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Merge N repeated k6 runs of the same scenario into one median result.
+
+Reduces run-to-run noise on shared CI hardware: a single k6 run's numbers
+can vary 20%+ between otherwise-identical commits, which previously
+produced false-positive regression alerts. Instead, each scenario now runs
+N times (run.sh) and this script:
+
+  - Takes the per-metric median across all N *_summary.run{i}.json files
+    (recursively, matching by JSON path - robust to new metrics without
+    code changes here) and writes it to *_summary.json, which is what
+    to-benchmark-action.py and generate-report.py already read.
+  - Picks the run whose peak RSS is closest to the group's median and
+    copies its *_server.run{i}.ndjson to *_server.ndjson, so the HTML
+    report's memory/FD chart still shows one real, representative time
+    series instead of a synthetic one.
+"""
+
+import json
+import os
+import statistics
+import sys
+
+
+def median_merge(values):
+    """Recursively merge parsed JSON values of identical shape, taking the
+    median of numeric leaves. Non-numeric or shape-mismatched leaves fall
+    back to the first run's value."""
+    first = values[0]
+
+    if isinstance(first, bool):
+        return first  # bool is an int subclass in Python; keep as-is
+
+    if isinstance(first, (int, float)):
+        nums = [v for v in values if isinstance(v, (int, float)) and not isinstance(v, bool)]
+        if len(nums) == len(values):
+            return statistics.median(nums)
+        return first
+
+    if isinstance(first, dict):
+        merged = {}
+        for key in first:
+            key_values = [v[key] if isinstance(v, dict) and key in v else first[key] for v in values]
+            merged[key] = median_merge(key_values)
+        return merged
+
+    if isinstance(first, list):
+        # Lists (e.g. threshold failure details) aren't aligned in any
+        # meaningful way across separate runs; keep the first run's list.
+        return first
+
+    return first
+
+
+def peak_rss(ndjson_path):
+    peak = 0
+    if not os.path.exists(ndjson_path):
+        return peak
+    with open(ndjson_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                peak = max(peak, json.loads(line).get("rss_kb", 0))
+            except json.JSONDecodeError:
+                continue
+    return peak
+
+
+def pick_median_run(ndjson_paths):
+    """Return the path whose peak RSS is the median of the group."""
+    existing = [p for p in ndjson_paths if os.path.exists(p)]
+    if not existing:
+        return None
+    by_peak = sorted((peak_rss(p), p) for p in existing)
+    return by_peak[len(by_peak) // 2][1]
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: merge-runs.py <results-dir> <scenario-name> <num-runs>", file=sys.stderr)
+        sys.exit(1)
+
+    results_dir, name, num_runs = sys.argv[1], sys.argv[2], int(sys.argv[3])
+
+    summary_paths = [
+        os.path.join(results_dir, f"{name}_summary.run{i}.json")
+        for i in range(1, num_runs + 1)
+    ]
+    summary_paths = [p for p in summary_paths if os.path.exists(p)]
+    if not summary_paths:
+        print(f"  No summary files found for {name}, skipping merge", file=sys.stderr)
+        return
+
+    summaries = [json.load(open(p)) for p in summary_paths]
+    merged = median_merge(summaries)
+    with open(os.path.join(results_dir, f"{name}_summary.json"), "w") as f:
+        json.dump(merged, f, indent=2)
+
+    ndjson_paths = [
+        os.path.join(results_dir, f"{name}_server.run{i}.ndjson")
+        for i in range(1, num_runs + 1)
+    ]
+    chosen = pick_median_run(ndjson_paths)
+    if chosen:
+        with open(chosen) as src, open(os.path.join(results_dir, f"{name}_server.ndjson"), "w") as dst:
+            dst.write(src.read())
+
+    print(f"  Merged {len(summary_paths)} runs for {name} (median)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -7,6 +7,11 @@
 #   --scenarios=LIST   Comma-separated scenario names (default: all)
 #   --output=DIR       Output directory (default: bench/results)
 #   --k6=PATH          Path to k6 binary (default: k6)
+#   --runs=N           Repeat each scenario N times and report the median
+#                      (default: 3). Shared CI hardware is noisy enough that
+#                      a single k6 run can vary 20%+ between otherwise-
+#                      identical commits; the median of a few runs is far
+#                      more stable.
 #
 # Examples:
 #   ./bench/run.sh ./websocketd
@@ -19,6 +24,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 K6="${K6:-k6}"
 OUTPUT_DIR=""
 SCENARIOS=""
+RUNS_PER_SCENARIO=3
 
 # --- Argument parsing ---
 
@@ -28,6 +34,7 @@ for arg in "$@"; do
     --scenarios=*) SCENARIOS="${arg#--scenarios=}" ;;
     --output=*)    OUTPUT_DIR="${arg#--output=}" ;;
     --k6=*)        K6="${arg#--k6=}" ;;
+    --runs=*)      RUNS_PER_SCENARIO="${arg#--runs=}" ;;
     --help|-h)
       sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
       exit 0
@@ -134,7 +141,66 @@ wait_for_port() {
   done
 }
 
-# Run a single scenario.
+# Run one iteration of a scenario, writing to run-suffixed output files.
+# Usage: run_scenario_once <run_index> <name> <script> <backend> <ws_flags> <k6_env>
+run_scenario_once() {
+  local run_index="$1"
+  local name="$2"
+  local script="$3"
+  local backend="$4"
+  local ws_flags="$5"
+  local k6_env="$6"
+
+  local port=$(find_free_port)
+  echo "--- $name run $run_index/$RUNS_PER_SCENARIO (port $port) ---"
+
+  # Start websocketd
+  $WEBSOCKETD_BIN --port="$port" --address=127.0.0.1 $ws_flags "$backend" \
+    >/dev/null 2>"$OUTPUT_DIR/${name}_ws_stderr.run${run_index}.log" &
+  local ws_pid=$!
+
+  if ! wait_for_port "$port" 10; then
+    kill "$ws_pid" 2>/dev/null; wait "$ws_pid" 2>/dev/null
+    echo "SKIP: $name run $run_index (server failed to start)"
+    return 1
+  fi
+
+  # Start metrics collector
+  "$SCRIPT_DIR/lib/collect-metrics.sh" "$ws_pid" "$OUTPUT_DIR/${name}_server.run${run_index}.ndjson" &
+  local collector_pid=$!
+
+  # Run k6. Output goes to a log first: piping k6 straight into sed would
+  # make $? report sed's status, silently discarding k6 failures.
+  local k6_exit=0
+  $K6 run \
+    --summary-export="$OUTPUT_DIR/${name}_summary.run${run_index}.json" \
+    --out "json=$OUTPUT_DIR/${name}_k6.run${run_index}.json" \
+    -e "WS_PORT=$port" \
+    $k6_env \
+    --quiet \
+    "$SCRIPT_DIR/scenarios/$script" >"$OUTPUT_DIR/${name}_k6.run${run_index}.log" 2>&1 || k6_exit=$?
+  sed "s/^/  /" "$OUTPUT_DIR/${name}_k6.run${run_index}.log"
+
+  # Stop websocketd and collector (suppress exit-on-signal noise)
+  kill "$ws_pid" 2>/dev/null
+  wait "$ws_pid" 2>/dev/null || true
+  kill "$collector_pid" 2>/dev/null
+  wait "$collector_pid" 2>/dev/null || true
+
+  if [ "$k6_exit" -eq 99 ]; then
+    # k6 exits 99 when thresholds are crossed — advisory on shared hardware.
+    echo "  WARN: $name run $run_index crossed k6 thresholds"
+  elif [ "$k6_exit" -ne 0 ]; then
+    echo "  ERROR: $name run $run_index exited with code $k6_exit"
+    return 1
+  fi
+  return 0
+}
+
+# Run a scenario RUNS_PER_SCENARIO times and merge the results into a single
+# median (see lib/merge-runs.py). A single k6 run on shared CI hardware is
+# noisy enough to produce false-positive regression alerts; repeating and
+# taking the median is far more stable without needing dedicated hardware.
 # Usage: run_scenario <name> <k6_script> [extra_ws_flags...] [-- k6_env_args...]
 run_scenario() {
   local name="$1"
@@ -162,51 +228,23 @@ run_scenario() {
     fi
   done
 
-  local port=$(find_free_port)
-  echo "--- $name (port $port) ---"
+  local run_index=1
+  local any_failed=0
+  while [ "$run_index" -le "$RUNS_PER_SCENARIO" ]; do
+    if ! run_scenario_once "$run_index" "$name" "$script" "$backend" "$ws_flags" "$k6_env"; then
+      any_failed=1
+    fi
+    run_index=$((run_index + 1))
+  done
+  echo ""
 
-  # Start websocketd
-  $WEBSOCKETD_BIN --port="$port" --address=127.0.0.1 $ws_flags "$backend" \
-    >/dev/null 2>"$OUTPUT_DIR/${name}_ws_stderr.log" &
-  local ws_pid=$!
-
-  if ! wait_for_port "$port" 10; then
-    kill "$ws_pid" 2>/dev/null; wait "$ws_pid" 2>/dev/null
-    echo "SKIP: $name (server failed to start)"
+  if [ "$any_failed" -eq 1 ]; then
+    echo "  FAILED: $name (at least one of $RUNS_PER_SCENARIO runs failed)"
     FAILED_SCENARIOS="$FAILED_SCENARIOS $name"
     return 0 # returning non-zero would abort the whole run under set -e
   fi
 
-  # Start metrics collector
-  "$SCRIPT_DIR/lib/collect-metrics.sh" "$ws_pid" "$OUTPUT_DIR/${name}_server.ndjson" &
-  local collector_pid=$!
-
-  # Run k6. Output goes to a log first: piping k6 straight into sed would
-  # make $? report sed's status, silently discarding k6 failures.
-  local k6_exit=0
-  $K6 run \
-    --summary-export="$OUTPUT_DIR/${name}_summary.json" \
-    --out "json=$OUTPUT_DIR/${name}_k6.json" \
-    -e "WS_PORT=$port" \
-    $k6_env \
-    --quiet \
-    "$SCRIPT_DIR/scenarios/$script" >"$OUTPUT_DIR/${name}_k6.log" 2>&1 || k6_exit=$?
-  sed "s/^/  /" "$OUTPUT_DIR/${name}_k6.log"
-
-  # Stop websocketd and collector (suppress exit-on-signal noise)
-  kill "$ws_pid" 2>/dev/null
-  wait "$ws_pid" 2>/dev/null || true
-  kill "$collector_pid" 2>/dev/null
-  wait "$collector_pid" 2>/dev/null || true
-
-  if [ "$k6_exit" -eq 99 ]; then
-    # k6 exits 99 when thresholds are crossed — advisory on shared hardware.
-    echo "  WARN: $name crossed k6 thresholds"
-  elif [ "$k6_exit" -ne 0 ]; then
-    echo "  ERROR: k6 exited with code $k6_exit"
-    FAILED_SCENARIOS="$FAILED_SCENARIOS $name"
-  fi
-  echo ""
+  python3 "$SCRIPT_DIR/lib/merge-runs.py" "$OUTPUT_DIR" "$name" "$RUNS_PER_SCENARIO"
 }
 
 # --- Define default scenarios ---


### PR DESCRIPTION
## Summary

Follow-up to the benchmark flakiness discussed on #462/#463/#464: a single k6 run on shared GitHub Actions runners can vary 20%+ between otherwise-identical commits, which was producing false-positive regression alerts (confirmed directly this session — a docs-only PR touching zero Go code got flagged for a 24% peak-RSS "regression").

- `bench/run.sh` now repeats each scenario 3 times by default (`--runs=N` to change; `--runs=1` restores the old single-run behavior) and merges the results before handing off to the existing report/regression-detection scripts, which are otherwise **unchanged**.
- New `bench/lib/merge-runs.py`:
  - Takes the per-metric **median** across all N `*_summary.run{i}.json` files (recursively, matched by JSON path — robust to future metric additions without touching this script).
  - For server RSS/FDs, merging the time series wouldn't produce a real one, so it picks the run whose peak RSS is closest to the group's median and uses that as `*_server.ndjson` — the HTML report's memory chart still shows one genuine run.
  - If any of the N runs fails outright, the whole scenario is still reported as failed (not silently averaged over fewer survivors).
- Bumped `alert-threshold` from 15% → 25%: median-of-3 removes most of the noise on its own, so this covers what's left rather than carrying the full slack alone.
- Fixed a stale line in `bench/README.md`'s CI Integration section that still claimed regressions "block merges" — that's been advisory-only (`fail-on-alert: false`) since the k6-install fix earlier in this PR chain.

## Testing

- `go build`/`go vet`/`gofmt -l .` clean, `go test ./... -race` passes (no Go source touched, but confirming nothing broke)
- `sh -n bench/run.sh` and `python3 -m py_compile bench/lib/merge-runs.py` clean
- Verified `merge-runs.py` in isolation with synthetic data: 3 summaries with values {20,30,40} → merged median correctly 30; 3 ndjson files with peak RSS {6000,9000,8000} KB → correctly selected the 8000 KB run as the representative `_server.ndjson`
- Verified the full `run.sh` pipeline end-to-end with a stub k6 binary: 3 iterations run, correct median flows through to `benchmark-data.json`, and a simulated k6 failure on run 2/3 correctly fails the whole scenario (exit code 1, no merged `summary.json` produced) — identical semantics to the prior single-run behavior
- The real k6 run on this PR's own CI is the actual end-to-end validation of the bench job itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr

---
_Generated by [Claude Code](https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr)_