### PR TITLE
Modernize JS in examples and README tutorial (#465)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Version 0.5.0 (Apr 26, 2026)
 
+* Modernized JS in examples/nodejs and examples/html and the README
+  tutorial snippet (var -> const, function expressions -> arrows,
+  string concatenation -> template literals); behavior unchanged (#465)
 * Benchmark suite now runs each scenario 3 times and reports the median
   (bench/run.sh --runs=N), cutting shared-CI-runner noise that was
   producing false-positive regression alerts; alert threshold raised

--- a/README.md
+++ b/README.md
@@ -81,15 +81,15 @@ __count.html__:
   }
 
   // setup websocket with callbacks
-  var ws = new WebSocket('ws://localhost:8080/');
-  ws.onopen = function() {
+  const ws = new WebSocket('ws://localhost:8080/');
+  ws.onopen = () => {
     log('CONNECT');
   };
-  ws.onclose = function() {
+  ws.onclose = () => {
     log('DISCONNECT');
   };
-  ws.onmessage = function(event) {
-    log('MESSAGE: ' + event.data);
+  ws.onmessage = (event) => {
+    log(`MESSAGE: ${event.data}`);
   };
 </script>
 ```

--- a/examples/html/count.html
+++ b/examples/html/count.html
@@ -16,14 +16,14 @@
     <div id="count"></div>
 
     <script>
-      var ws = new WebSocket('ws://' + (location.host ? location.host : "localhost:8080") + "/");
-      ws.onopen = function() {
+      const ws = new WebSocket(`ws://${location.host || 'localhost:8080'}/`);
+      ws.onopen = () => {
         document.body.style.backgroundColor = '#cfc';
       };
-      ws.onclose = function() {
+      ws.onclose = () => {
         document.body.style.backgroundColor = null;
       };
-      ws.onmessage = function(event) {
+      ws.onmessage = (event) => {
         document.getElementById('count').textContent = event.data;
       };
     </script>

--- a/examples/nodejs/count.js
+++ b/examples/nodejs/count.js
@@ -1,16 +1,8 @@
-(function(){
-	var counter = 0;
-	var echo = function(){
-		if (counter === 10){
-			return;
-		}
+async function main() {
+  for (let counter = 1; counter <= 10; counter++) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    process.stdout.write(`${counter}\n`);
+  }
+}
 
-		setTimeout(function(){
-			counter++;
-			echo();
-			process.stdout.write(counter.toString() + "\n");
-		}, 500);
-	}
-
-	echo();
-})();
+main();

--- a/examples/nodejs/greeter.js
+++ b/examples/nodejs/greeter.js
@@ -2,9 +2,9 @@
 // https://nodejs.org/api/process.html#process_process_stdin
 process.stdin.setEncoding('utf8');
 
-process.stdin.on('readable', function() {
-  var chunk = process.stdin.read();
+process.stdin.on('readable', () => {
+  const chunk = process.stdin.read();
   if (chunk !== null) {
-    process.stdout.write('data: ' + chunk);
+    process.stdout.write(`data: ${chunk}`);
   }
 });


### PR DESCRIPTION
Closes #465.

Updates `examples/nodejs/count.js`, `examples/nodejs/greeter.js`, `examples/html/count.html`, and the README's inline tutorial `<script>` snippet from pre-ES6 style to modern JS:

- `var` → `const`/`let`
- `function() {}` expressions → arrow functions
- string concatenation → template literals
- `count.js`'s nested `setTimeout` callback recursion → `async`/`await`

No behavior changes — `count.js` still waits 500ms before printing the first number, intentionally preserving the existing (pre-existing, out-of-scope) inconsistency with `bash/count.sh`, which prints immediately.

Out of scope, left untouched:
- `examples/windows-jscript/*` — intentionally legacy demo target
- `bench/scenarios/*` — internal k6 tooling, already modern ES
- `libwebsocketd/console.go`'s embedded dev-console JS — separate refresh under discussion in #466

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Manually diffed each file to confirm only syntax changed, not behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01M882UWfvyaq5KGvaV37idr)_